### PR TITLE
feat: add JSON patch viewer component

### DIFF
--- a/apps/web/src/components/diff/json-patch-viewer.tsx
+++ b/apps/web/src/components/diff/json-patch-viewer.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import * as React from 'react'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Textarea,
+} from '@originfd/ui'
+import {
+  computeJsonPatch,
+  groupDiffsBySection,
+  getValueByPath,
+  type PatchOperation,
+} from './utils'
+
+interface JsonPatchViewerProps {
+  original: Record<string, any>
+  updated: Record<string, any>
+  onApprove?: (args: { patch: PatchOperation[]; rationale: string }) => void
+  onReject?: (args: { patch: PatchOperation[]; rationale: string }) => void
+}
+
+export default function JsonPatchViewer({
+  original,
+  updated,
+  onApprove,
+  onReject,
+}: JsonPatchViewerProps) {
+  const patch = React.useMemo(
+    () => computeJsonPatch(original, updated),
+    [original, updated]
+  )
+  const sections = React.useMemo(() => groupDiffsBySection(patch), [patch])
+  const [rationale, setRationale] = React.useState('')
+
+  const copyPatch = () => {
+    navigator.clipboard.writeText(JSON.stringify(patch, null, 2))
+  }
+
+  const approve = () => onApprove?.({ patch, rationale })
+  const reject = () => onReject?.({ patch, rationale })
+
+  return (
+    <div>
+      <div className="flex flex-col gap-2 mb-4 md:flex-row">
+        <Textarea
+          placeholder="Rationale"
+          value={rationale}
+          onChange={(e) => setRationale(e.target.value)}
+          className="flex-1"
+        />
+        <div className="flex gap-2">
+          <Button variant="secondary" onClick={copyPatch}>
+            Copy Patch
+          </Button>
+          <Button onClick={approve}>Approve</Button>
+          <Button variant="destructive" onClick={reject}>
+            Reject
+          </Button>
+        </div>
+      </div>
+      {Object.entries(sections).map(([section, ops]) => (
+        <Card key={section} className="mb-4">
+          <CardHeader>
+            <CardTitle>{section}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {ops.map((op, idx) => {
+                const oldVal = getValueByPath(original, op.path)
+                const newVal = op.value
+                const isNumeric =
+                  typeof oldVal === 'number' && typeof newVal === 'number'
+                const delta = isNumeric ? newVal - oldVal : null
+                return (
+                  <li key={idx} className="flex items-center gap-2">
+                    <span className="text-sm flex-1">
+                      {op.path.split('/').slice(2).join('/')}
+                    </span>
+                    <Badge variant="outline">{String(oldVal)}</Badge>
+                    <span>→</span>
+                    <Badge
+                      variant={
+                        delta !== null
+                          ? delta >= 0
+                            ? 'default'
+                            : 'destructive'
+                          : 'default'
+                      }
+                    >
+                      {String(newVal)}
+                      {delta !== null && (
+                        <span className="ml-1 text-xs">
+                          ({delta >= 0 ? '+' : ''}
+                          {delta})
+                        </span>
+                      )}
+                    </Badge>
+                  </li>
+                )
+              })}
+            </ul>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+

--- a/apps/web/src/components/diff/utils.ts
+++ b/apps/web/src/components/diff/utils.ts
@@ -1,0 +1,58 @@
+export interface PatchOperation {
+  op: 'add' | 'remove' | 'replace'
+  path: string
+  value?: any
+}
+
+function isObject(value: any): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function computeJsonPatch(
+  source: any,
+  target: any,
+  basePath = ''
+): PatchOperation[] {
+  const patch: PatchOperation[] = []
+  const keys = new Set([
+    ...Object.keys(source || {}),
+    ...Object.keys(target || {}),
+  ])
+
+  for (const key of keys) {
+    const src = source ? source[key] : undefined
+    const tgt = target ? target[key] : undefined
+    const path = `${basePath}/${key}`
+
+    if (src === undefined && tgt !== undefined) {
+      patch.push({ op: 'add', path, value: tgt })
+    } else if (src !== undefined && tgt === undefined) {
+      patch.push({ op: 'remove', path })
+    } else if (isObject(src) && isObject(tgt)) {
+      patch.push(...computeJsonPatch(src, tgt, path))
+    } else if (src !== tgt) {
+      patch.push({ op: 'replace', path, value: tgt })
+    }
+  }
+
+  return patch
+}
+
+export function getValueByPath(obj: any, path: string): any {
+  return path
+    .split('/')
+    .slice(1)
+    .reduce((acc: any, key: string) => (acc ? acc[key] : undefined), obj)
+}
+
+export function groupDiffsBySection(
+  patch: PatchOperation[]
+): Record<string, PatchOperation[]> {
+  return patch.reduce((acc, op) => {
+    const [, section] = op.path.split('/')
+    if (!section) return acc
+    acc[section] = acc[section] || []
+    acc[section].push(op)
+    return acc
+  }, {} as Record<string, PatchOperation[]>)
+}

--- a/apps/web/tests/diff/json-patch-viewer.test.tsx
+++ b/apps/web/tests/diff/json-patch-viewer.test.tsx
@@ -1,0 +1,16 @@
+import { strict as assert } from 'node:assert'
+import test from 'node:test'
+import { groupDiffsBySection, PatchOperation } from '../../src/components/diff/utils'
+
+test('groups patch operations by top-level section', () => {
+  const patch: PatchOperation[] = [
+    { op: 'replace', path: '/meta/title', value: 'New' },
+    { op: 'add', path: '/details/age', value: 42 },
+    { op: 'replace', path: '/meta/author', value: 'Jane' },
+  ]
+
+  const grouped = groupDiffsBySection(patch)
+  assert.deepEqual(Object.keys(grouped).sort(), ['details', 'meta'])
+  assert.equal(grouped.meta.length, 2)
+  assert.equal(grouped.details[0].path, '/details/age')
+})


### PR DESCRIPTION
## Summary
- add JsonPatchViewer component with toolbar actions and KPI diff display
- factor json patch utilities and grouping logic
- test diff grouping by section

## Testing
- `pnpm --filter @originfd/web lint` *(fails: react/no-unescaped-entities, etc.)*
- `npx tsx apps/web/tests/diff/json-patch-viewer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c112bd48608329bf2362fc5890a8c8