### PR TITLE
Use relative bridge API base URL by default

### DIFF
--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -454,10 +454,16 @@ export class OriginFDClient {
 // Default client instance
 // Use real backend API instead of mock endpoints
 // Use environment variable for API base URL in production
-const API_BASE_URL =
-  typeof window !== "undefined"
-    ? (window as any).__ORIGINFD_API_BASE__ || "http://localhost:8000"
-    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
+const API_BASE_URL = (() => {
+  const browserBase =
+    typeof window !== "undefined"
+      ? (window as any).__ORIGINFD_API_BASE__
+      : undefined;
+
+  const envBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  return browserBase || envBase || "/api/bridge";
+})();
 
 export const apiClient = new OriginFDClient(API_BASE_URL);
 


### PR DESCRIPTION
## Summary
- default the API client base URL to the in-app /api/bridge proxy unless an explicit override is provided by window.__ORIGINFD_API_BASE__ or NEXT_PUBLIC_API_BASE_URL

## Testing
- pnpm --filter @originfd/web lint
- pnpm --filter @originfd/web dev (manual curl against http://localhost:3000/api/bridge/auth/login)

------
https://chatgpt.com/codex/tasks/task_e_68cf4306db648329bb7aedc5af397da2