### PR TITLE
Fix document version hash tracking and extend tests

### DIFF
--- a/services/api/api/routers/documents.py
+++ b/services/api/api/routers/documents.py
@@ -279,6 +279,7 @@ async def apply_document_patch(
 
         # Update database
         new_version = document.current_version + 1
+        old_hash = document.content_hash
         new_hash = odl_doc.meta.versioning.content_hash
 
         # Update document record
@@ -293,7 +294,7 @@ async def apply_document_patch(
             document_id=document.id,
             version_number=new_version,
             content_hash=new_hash,
-            previous_hash=document.content_hash,
+            previous_hash=old_hash,
             change_summary=request.change_summary,
             patch_operations=request.patch,
             evidence_uris=request.evidence,


### PR DESCRIPTION
## Summary
- capture the existing document hash before mutation and store it as the version's previous_hash
- expand the document patch test to verify hash changes and previous_hash tracking

## Testing
- pytest -o addopts= tests/api/test_documents_patch.py

------
https://chatgpt.com/codex/tasks/task_e_68cfe6522d74832984df047bea4ac98f