### PR TITLE
Add psutil dependency across Python configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ aiofiles = "^23.2.1"
 aioredis = "^2.0.1"
 networkx = "^3.2.1"
 numpy = "^1.26.0"
+psutil = "^5.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,3 +24,6 @@ pytest-mock==3.12.0
 
 # Local development
 watchdog==3.0.0
+
+# System and process utilities
+psutil==5.9.8

--- a/requirements.in
+++ b/requirements.in
@@ -19,6 +19,9 @@ pydantic-settings>=2.1.0,<2.2.0
 # Environment and configuration
 python-dotenv>=1.0.0,<1.1.0
 
+# System and process utilities
+psutil>=5.9.0,<5.10.0
+
 # Date and time utilities
 python-dateutil>=2.8.2,<2.9.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,9 @@ pydantic-settings==2.1.0
 # Environment and configuration
 python-dotenv==1.0.0
 
+# System and process utilities
+psutil==5.9.8
+
 # Date and time utilities
 python-dateutil==2.8.2
 


### PR DESCRIPTION
## Summary
- add the psutil runtime dependency to Poetry's main dependencies
- pin psutil in the requirements input and generated requirement sets for parity

## Testing
- poetry install --without ai
- poetry run python -c "import psutil"


------
https://chatgpt.com/codex/tasks/task_e_68d079ac955c83298cbc4977fa2c9b45