### PR TITLE
Implement tenant-aware auth dependency

### DIFF
--- a/services/api/api/routers/alarms.py
+++ b/services/api/api/routers/alarms.py
@@ -7,7 +7,7 @@ import random
 from datetime import datetime
 from typing import Dict, List
 
-from api.routers.auth import get_current_user
+from deps import get_current_user
 from core.database import SessionDep
 from fastapi import (
     APIRouter,

--- a/services/api/api/routers/component_integration.py
+++ b/services/api/api/routers/component_integration.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import models
-from core.auth import get_current_user
+from deps import get_current_user
 from core.database import SessionDep
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field

--- a/services/api/api/routers/components.py
+++ b/services/api/api/routers/components.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import models
-from api.routers.auth import get_current_user
+from deps import get_current_user
 from core.database import SessionDep
 from core.performance import (
     cached_response,

--- a/services/api/api/routers/documents.py
+++ b/services/api/api/routers/documents.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 # from core.rbac import guard_patch, has_document_access  # TODO: Implement RBAC
 import models
-from core.auth import get_current_user
+from deps import get_current_user
 from core.database import SessionDep
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from odl_sd.schemas import OdlSdDocument

--- a/services/api/api/routers/performance.py
+++ b/services/api/api/routers/performance.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
-from api.routers.auth import get_current_user
+from deps import get_current_user
 from core.performance import db_monitor, health_monitor, rate_limiter, response_cache
 from core.redis_config import redis_config
 from fastapi import APIRouter, Depends, Query

--- a/services/api/api/routers/projects.py
+++ b/services/api/api/routers/projects.py
@@ -8,11 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
 import httpx
-
-
-# Simple auth bypass for testing
-def get_current_user(*args, **kwargs):
-    return {"id": "ab9c411c-5c5f-4eb0-8f94-5b998b9dd3fc", "email": "admin@originfd.com"}
+from deps import get_current_user
 
 
 from core.config import get_settings

--- a/services/api/api/routers/suppliers.py
+++ b/services/api/api/routers/suppliers.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import models
-from core.auth import get_current_user
+from deps import get_current_user
 from core.database import SessionDep
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, EmailStr, Field

--- a/services/api/core/permissions.py
+++ b/services/api/core/permissions.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
-from api.routers.auth import get_current_user
+from deps import get_current_user
 from core.database import get_db
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import and_

--- a/services/api/deps.py
+++ b/services/api/deps.py
@@ -1,0 +1,149 @@
+"""Shared FastAPI dependency utilities for authentication."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Annotated, Any, Dict, List
+
+import models
+from core.auth import verify_token
+from core.database import get_db
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session, joinedload
+
+logger = logging.getLogger(__name__)
+security = HTTPBearer(auto_error=True)
+
+
+def _normalize_roles(user: models.User, payload: Dict[str, Any]) -> List[str]:
+    """Extract role information from the JWT payload or user record."""
+
+    roles: List[str] = []
+
+    payload_roles = payload.get("roles")
+    if isinstance(payload_roles, list):
+        roles = [str(role) for role in payload_roles if role]
+
+    if not roles:
+        user_roles = getattr(user, "roles", None)
+        if isinstance(user_roles, list):
+            roles = [str(role) for role in user_roles if role]
+        elif user_roles:
+            roles = [str(user_roles)]
+
+    if not roles:
+        fallback_role = getattr(user, "role", None)
+        if fallback_role:
+            roles = [str(fallback_role)]
+
+    if not roles:
+        roles = ["user"]
+
+    return roles
+
+
+def _serialize_membership(membership: models.TenantMembership) -> Dict[str, Any]:
+    tenant = membership.tenant
+    return {
+        "tenant_id": str(membership.tenant_id),
+        "tenant_name": getattr(tenant, "name", None),
+        "tenant_slug": getattr(tenant, "slug", None),
+        "role": membership.role,
+        "is_default": bool(membership.is_default),
+    }
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Resolve the currently authenticated user including tenant bindings."""
+
+    token = (credentials.credentials or "").strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    payload = verify_token(token, token_type="access")
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing subject",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        user_uuid = uuid.UUID(str(user_id))
+    except (TypeError, ValueError) as exc:
+        logger.debug("Invalid user identifier in token: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    user: models.User | None = (
+        db.query(models.User)
+        .options(joinedload(models.User.tenant_memberships).joinedload(models.TenantMembership.tenant))
+        .filter(models.User.id == user_uuid)
+        .first()
+    )
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if hasattr(user, "is_active") and not bool(user.is_active):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is inactive",
+        )
+
+    active_memberships = [
+        m
+        for m in getattr(user, "tenant_memberships", [])
+        if bool(m.is_active) and (m.tenant is None or bool(getattr(m.tenant, "is_active", True)))
+    ]
+
+    if not active_memberships:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not bound to an active tenant",
+        )
+
+    default_membership = next(
+        (membership for membership in active_memberships if bool(membership.is_default)),
+        active_memberships[0],
+    )
+
+    memberships_payload = [_serialize_membership(m) for m in active_memberships]
+    for membership in memberships_payload:
+        membership["is_default"] = membership["tenant_id"] == str(default_membership.tenant_id)
+
+    user_roles = _normalize_roles(user, payload)
+
+    current_user = {
+        "id": str(user.id),
+        "email": getattr(user, "email", None),
+        "full_name": getattr(user, "full_name", None),
+        "is_active": bool(getattr(user, "is_active", True)),
+        "roles": user_roles,
+        "tenant_id": str(default_membership.tenant_id),
+        "tenant_slug": getattr(default_membership.tenant, "slug", None),
+        "tenants": memberships_payload,
+    }
+
+    return current_user
+
+
+CurrentUser = Annotated[Dict[str, Any], Depends(get_current_user)]

--- a/services/api/models/__init__.py
+++ b/services/api/models/__init__.py
@@ -14,7 +14,7 @@ from .supplier import Supplier
 
 # Import models in dependency order to avoid circular imports
 # Core models without foreign key dependencies first
-from .tenant import Tenant
+from .tenant import Tenant, TenantMembership
 from .user import User
 
 __all__ = [
@@ -23,6 +23,7 @@ __all__ = [
     "TimestampMixin",
     "TenantMixin",
     "Tenant",
+    "TenantMembership",
     "User",
     "Project",
     "Component",

--- a/services/api/models/user.py
+++ b/services/api/models/user.py
@@ -28,6 +28,21 @@ class User(Base, UUIDMixin, TimestampMixin):
 
     # Relationships
     projects = relationship("Project", back_populates="owner")
+    tenant_memberships = relationship(
+        "TenantMembership",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+    @property
+    def roles(self) -> list[str]:
+        """Return roles as a list for compatibility with token payloads."""
+        role_value = getattr(self, "role", None)
+        if isinstance(role_value, list):
+            return role_value
+        if role_value:
+            return [role_value]
+        return ["user"]
 
     def update_last_login(self) -> None:
         """Update last login timestamp."""

--- a/tests/api/test_component_integration.py
+++ b/tests/api/test_component_integration.py
@@ -26,7 +26,7 @@ if PACKAGES_ROOT not in sys.path:
 
 
 from api.routers import component_integration  # noqa: E402
-from core.auth import get_current_user  # noqa: E402
+from deps import get_current_user  # noqa: E402
 from core.database import SessionDep  # noqa: E402
 import models  # noqa: E402
 from models.document import DocumentVersion  # noqa: E402

--- a/tests/api/test_documents_patch.py
+++ b/tests/api/test_documents_patch.py
@@ -19,7 +19,7 @@ if PACKAGES_ROOT not in sys.path:
 
 from api.routers import documents  # noqa: E402
 from core.database import SessionDep  # noqa: E402
-from core.auth import get_current_user  # noqa: E402
+from deps import get_current_user  # noqa: E402
 import models  # noqa: E402
 from models.document import DocumentVersion  # noqa: E402
 


### PR DESCRIPTION
## Summary
- add a shared auth dependency that decodes JWTs, loads the user from the database, and returns tenant memberships
- introduce a TenantMembership ORM model and wire tenant/user relationships so membership information can be queried
- update routers, permission helpers, and tests to depend on the new tenant-aware helper instead of local stubs

## Testing
- pytest -o addopts="" tests/api/test_documents_patch.py tests/api/test_component_integration.py *(fails: sqlalchemy.exc.InvalidRequestError: Table 'suppliers' is already defined for this MetaData instance)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1917e60832991349d5ccc018b9e