### PR TITLE
Add document export endpoint and tests

### DIFF
--- a/services/api/api/utils/__init__.py
+++ b/services/api/api/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for the API layer."""

--- a/services/api/api/utils/document_serialization.py
+++ b/services/api/api/utils/document_serialization.py
@@ -1,0 +1,62 @@
+"""Helpers for producing canonical ODL-SD document exports.
+
+These helpers were extracted from the retired ``odl_sd_api`` module so new
+routers can continue to provide the same canonical JSON/YAML exports without
+re-implementing the response wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi.responses import JSONResponse, Response
+
+from odl_sd.schemas import OdlSdDocument
+
+
+def canonicalize_document(document_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a canonical representation of an ODL-SD document.
+
+    The ``odl_sd_api`` module historically normalised documents by parsing them
+    with :class:`OdlSdDocument` and emitting ``dict`` output via ``to_dict``.
+    Reusing the same approach guarantees that downstream tooling receives the
+    same canonical structure regardless of the storage backend.
+    """
+
+    odl_doc = OdlSdDocument.model_validate(document_data)
+    try:
+        return odl_doc.model_dump(by_alias=True, exclude_none=False, mode="json")
+    except TypeError:  # pragma: no cover - compatibility with older Pydantic
+        return odl_doc.dict(by_alias=True, exclude_none=False)
+
+
+def _build_filename(project_name: str, extension: str) -> str:
+    safe_name = project_name.replace(" ", "_") or "document"
+    return f"{safe_name}_odl.{extension}"
+
+
+def create_json_export_response(project_name: str, document: Dict[str, Any]) -> JSONResponse:
+    """Create the JSON export response used by the legacy API."""
+
+    filename = _build_filename(project_name, "json")
+    return JSONResponse(
+        content=document,
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+def create_yaml_export_response(project_name: str, document: Dict[str, Any]) -> Response:
+    """Create the YAML export response used by the legacy API."""
+
+    try:
+        import yaml
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive import
+        raise RuntimeError("YAML support requires PyYAML to be installed") from exc
+
+    filename = _build_filename(project_name, "yaml")
+    yaml_content = yaml.dump(document, default_flow_style=False)
+    return Response(
+        content=yaml_content,
+        media_type="application/x-yaml",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )

--- a/tests/api/documents/test_export.py
+++ b/tests/api/documents/test_export.py
@@ -1,0 +1,141 @@
+import os
+import sys
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+API_ROOT = os.path.join(PROJECT_ROOT, "services", "api")
+if API_ROOT not in sys.path:
+    sys.path.insert(0, API_ROOT)
+
+PACKAGES_ROOT = os.path.join(PROJECT_ROOT, "packages", "py")
+if PACKAGES_ROOT not in sys.path:
+    sys.path.insert(0, PACKAGES_ROOT)
+
+from api.routers import documents  # noqa: E402
+from api.utils.document_serialization import canonicalize_document  # noqa: E402
+from core.database import SessionDep  # noqa: E402
+from deps import get_current_user  # noqa: E402
+import models  # noqa: E402
+
+
+class FakeQuery:
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+
+class FakeSession:
+    def __init__(self, document):
+        self.document = document
+
+    def query(self, model):
+        if model is models.Document:
+            return FakeQuery(self.document)
+        return FakeQuery(None)
+
+
+@pytest.fixture()
+def sample_document():
+    timestamp = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return {
+        "$schema": "https://odl-sd.org/schemas/v4.1/document.json",
+        "schema_version": "4.1",
+        "meta": {
+            "project": "Demo Export",
+            "domain": "PV",
+            "scale": "UTILITY",
+            "units": {
+                "system": "SI",
+                "currency": "USD",
+                "coordinate_system": "EPSG:4326",
+            },
+            "timestamps": {"created_at": timestamp, "updated_at": timestamp},
+            "versioning": {
+                "document_version": "1.0.0",
+                "content_hash": "sha256:export",
+            },
+        },
+        "hierarchy": {"sites": [{"id": "site-1"}]},
+        "requirements": {},
+        "libraries": {},
+        "instances": [],
+        "connections": [],
+        "analysis": [],
+        "audit": [],
+        "data_management": {
+            "partitioning_enabled": False,
+            "external_refs_enabled": False,
+            "streaming_enabled": False,
+            "max_document_size_mb": 100,
+        },
+    }
+
+
+@pytest.fixture()
+def test_client(sample_document):
+    app = FastAPI()
+    app.include_router(documents.router, prefix="/documents")
+
+    tenant_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    document = SimpleNamespace(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        project_name=sample_document["meta"]["project"],
+        portfolio_id=None,
+        domain=sample_document["meta"]["domain"],
+        scale=sample_document["meta"]["scale"],
+        current_version=1,
+        content_hash=sample_document["meta"]["versioning"]["content_hash"],
+        document_data=sample_document,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        is_active=True,
+    )
+
+    fake_session = FakeSession(document)
+
+    app.dependency_overrides[SessionDep] = lambda: fake_session
+    app.dependency_overrides[get_current_user] = lambda: {
+        "id": str(user_id),
+        "tenant_id": str(tenant_id),
+    }
+
+    client = TestClient(app)
+    client.document = document  # type: ignore[attr-defined]
+    return client
+
+
+def test_export_document_json(test_client, sample_document):
+    response = test_client.get(f"/documents/{test_client.document.id}/export?format=json")
+
+    assert response.status_code == 200
+    assert response.headers["content-disposition"].endswith("_odl.json")
+    expected = canonicalize_document(sample_document)
+    assert response.json() == expected
+
+
+def test_export_document_yaml(test_client, sample_document):
+    response = test_client.get(f"/documents/{test_client.document.id}/export?format=yaml")
+
+    assert response.status_code == 200
+    assert response.headers["content-disposition"].endswith("_odl.yaml")
+
+    exported = yaml.safe_load(response.text)
+    expected = canonicalize_document(sample_document)
+    assert exported == expected


### PR DESCRIPTION
## Summary
- add a GET /documents/{doc_id}/export route that returns canonical JSON or YAML exports using the legacy serialization helpers
- extract reusable canonicalization and response helpers into api.utils so routers can share the export logic
- add focused API tests that cover both JSON and YAML exports for the documents router

## Testing
- pytest tests/api/documents/test_export.py

------
https://chatgpt.com/codex/tasks/task_e_68d0e7ae6e3483298d21adb8e4f1cce3