### PR TITLE
Add document role checks and permission config

### DIFF
--- a/services/api/core/role_config.py
+++ b/services/api/core/role_config.py
@@ -1,0 +1,38 @@
+"""Centralized role-to-permission configuration for API services."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+# NOTE: Permissions are expressed using their string representation to avoid
+# circular imports with ``core.permissions``. The ``Permission`` enum in that
+# module should contain matching values for each string defined below.
+ROLE_ACTION_MAP: Dict[str, List[str]] = {
+    # Read-only consumers of project documentation.
+    "viewer": [
+        "document:read",
+    ],
+    # Engineers can both inspect and iterate on documentation updates.
+    "engineer": [
+        "document:read",
+        "document:update",
+        "document:version",
+    ],
+    # Project managers share similar capabilities to engineers but may also
+    # coordinate version management activities.
+    "project_manager": [
+        "document:read",
+        "document:update",
+        "document:version",
+    ],
+    # Administrators retain full control of documentation lifecycle actions.
+    "admin": [
+        "document:create",
+        "document:read",
+        "document:update",
+        "document:delete",
+        "document:version",
+    ],
+}
+


### PR DESCRIPTION
## Summary
- enforce permission checks on document read, export, and patch endpoints using the shared authorization utilities
- add a centralized role-to-permission mapping for core document roles and enhance permission handling for multi-role users
- update document API tests to cover role-aware behavior and ensure unauthorized roles receive 403 responses

## Testing
- pytest tests/api/test_documents_patch.py tests/api/documents/test_export.py *(fails: SQLAlchemy models require full database configuration and relationships during import)*

------
https://chatgpt.com/codex/tasks/task_e_68d0eaa8f14883298597e798532a23a4