### PR TITLE
Add orchestrator task schema and tests

### DIFF
--- a/services/orchestrator/api/routers/tasks.py
+++ b/services/orchestrator/api/routers/tasks.py
@@ -1,9 +1,132 @@
-from fastapi import APIRouter
+"""Task routing for the orchestrator service."""
 
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List, Optional
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field, field_validator
+
+
+class TaskStatus(str, Enum):
+    """Possible lifecycle states for an accepted task."""
+
+    QUEUED = "queued"
+
+
+class ProjectContext(BaseModel):
+    """Context payload emitted by ``POST /projects`` when seeding a task."""
+
+    project_id: UUID = Field(..., description="Unique identifier for the project")
+    project_name: str = Field(..., min_length=1, max_length=255)
+    domain: str = Field(..., min_length=1, max_length=255)
+    scale: str = Field(..., min_length=1, max_length=255)
+
+    @field_validator("project_name", "domain", "scale")
+    @classmethod
+    def _strip_strings(cls, value: str) -> str:
+        """Ensure string fields are normalized and non-empty."""
+
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Value cannot be empty")
+        return cleaned
+
+
+class TaskCreateRequest(BaseModel):
+    """Incoming task payload used by other services."""
+
+    task_type: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=500)
+    context: ProjectContext
+    tenant_id: UUID = Field(..., description="Tenant identifier scoped to the task")
+    user_id: UUID = Field(..., description="User initiating the task")
+
+    @field_validator("task_type", mode="before")
+    @classmethod
+    def _normalize_task_type(cls, value: object) -> str:
+        if isinstance(value, str):
+            cleaned = value.strip()
+            if not cleaned:
+                raise ValueError("task_type cannot be empty")
+            return cleaned
+        raise ValueError("task_type must be a string")
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def _normalize_description(cls, value: Optional[object]) -> Optional[str]:
+        if value is None:
+            return value
+        if isinstance(value, str):
+            cleaned = value.strip()
+            return cleaned or None
+        raise ValueError("description must be a string if provided")
+
+
+class TaskRecord(BaseModel):
+    """Persisted task information."""
+
+    id: UUID
+    task_type: str
+    description: Optional[str]
+    context: ProjectContext
+    tenant_id: UUID
+    user_id: UUID
+    status: TaskStatus
+    created_at: datetime
+
+
+class TaskAcceptedResponse(BaseModel):
+    """Response returned when a task is accepted for processing."""
+
+    task_id: UUID
+    status: TaskStatus
+
+
+class InMemoryTaskStore:
+    """Very small in-memory persistence layer used for testing."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[UUID, TaskRecord] = {}
+
+    def add(self, task: TaskRecord) -> TaskRecord:
+        self._tasks[task.id] = task
+        return task
+
+    def list(self) -> List[TaskRecord]:
+        return list(self._tasks.values())
+
+    def clear(self) -> None:
+        self._tasks.clear()
+
+
+task_store = InMemoryTaskStore()
 router = APIRouter()
 
 
 @router.get("/")
-async def list_tasks():
-    """List active tasks (placeholder)."""
-    return {"tasks": []}
+async def list_tasks() -> Dict[str, List[TaskRecord]]:
+    """List tasks accepted by the orchestrator."""
+
+    return {"tasks": task_store.list()}
+
+
+@router.post("/", response_model=TaskAcceptedResponse, status_code=201)
+async def create_task(task: TaskCreateRequest) -> TaskAcceptedResponse:
+    """Accept a new task submission from dependent services."""
+
+    record = TaskRecord(
+        id=uuid4(),
+        task_type=task.task_type,
+        description=task.description,
+        context=task.context,
+        tenant_id=task.tenant_id,
+        user_id=task.user_id,
+        status=TaskStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+    )
+    task_store.add(record)
+    return TaskAcceptedResponse(task_id=record.id, status=record.status)

--- a/tests/orchestrator/test_tasks.py
+++ b/tests/orchestrator/test_tasks.py
@@ -1,0 +1,75 @@
+"""Tests for the orchestrator task ingestion endpoint."""
+
+from pathlib import Path
+import sys
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from services.orchestrator.api.routers import tasks
+
+
+def _client() -> TestClient:
+    """Create a lightweight FastAPI app mounting the task router."""
+
+    app = FastAPI()
+    app.include_router(tasks.router, prefix="/tasks")
+    return TestClient(app)
+
+
+def _project_task_payload() -> dict:
+    """Return a payload shaped like the project creation hook emits."""
+
+    return {
+        "task_type": "project_initialization",
+        "description": "Initialize project knowledge graph",
+        "context": {
+            "project_id": str(uuid4()),
+            "project_name": "Demo Solar Farm",
+            "domain": "solar",
+            "scale": "UTILITY",
+        },
+        "tenant_id": str(uuid4()),
+        "user_id": str(uuid4()),
+    }
+
+
+def test_create_task_accepts_project_payload() -> None:
+    """A project initialization payload should be accepted and persisted."""
+
+    client = _client()
+    tasks.task_store.clear()
+
+    payload = _project_task_payload()
+    response = client.post("/tasks/", json=payload)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["status"] == "queued"
+    assert "task_id" in data
+
+    list_response = client.get("/tasks/")
+    stored_tasks = list_response.json()["tasks"]
+    assert len(stored_tasks) == 1
+    stored_task = stored_tasks[0]
+    assert stored_task["context"]["project_id"] == payload["context"]["project_id"]
+    assert stored_task["task_type"] == payload["task_type"]
+
+
+def test_create_task_requires_project_context() -> None:
+    """Missing critical context fields should return a validation error."""
+
+    client = _client()
+    tasks.task_store.clear()
+
+    payload = _project_task_payload()
+    payload["context"].pop("project_id")
+
+    response = client.post("/tasks/", json=payload)
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add task ingestion schemas, responses, and in-memory persistence to the orchestrator tasks router
- normalize incoming payloads from POST /projects and return task identifiers
- add FastAPI tests to validate successful intake and validation failures for orchestrator tasks

## Testing
- pytest tests/orchestrator/test_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68d0eab5a50883299c3c00734a0fec98