### PR TITLE
Add orchestrator webhook handler and document service

### DIFF
--- a/services/api/api/routers/orchestrator.py
+++ b/services/api/api/routers/orchestrator.py
@@ -1,0 +1,148 @@
+"""Webhook endpoints for orchestrator callbacks."""
+
+import hashlib
+import hmac
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import AliasChoices, BaseModel, Field
+
+from api.services import (
+    DocumentNotFoundError,
+    DocumentPatchError,
+    DocumentPatchResult,
+    DocumentService,
+    DocumentValidationError,
+    DocumentVersionConflictError,
+)
+from core.config import Settings, get_settings
+from core.database import SessionDep
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+SIGNATURE_HEADER = "X-Orchestrator-Signature"
+SIGNATURE_PREFIX = "sha256="
+
+
+class OrchestratorEvent(BaseModel):
+    """Envelope for orchestrator webhook events."""
+
+    event: str
+    data: Dict[str, Any]
+    event_id: Optional[uuid.UUID] = Field(default=None, alias="id")
+    timestamp: Optional[datetime] = None
+
+    model_config = {"populate_by_name": True}
+
+
+class DocumentPatchPayload(BaseModel):
+    """Payload describing a document patch operation."""
+
+    document_id: uuid.UUID
+    tenant_id: uuid.UUID
+    patch: list[Dict[str, Any]]
+    document_version: int = Field(
+        ..., validation_alias=AliasChoices("version", "document_version")
+    )
+    change_summary: Optional[str] = None
+    evidence: Optional[list[str]] = Field(default_factory=list)
+    actor_id: Optional[uuid.UUID] = None
+    actor_type: str = "system"
+
+    model_config = {"populate_by_name": True}
+
+
+def get_document_service(session: SessionDep) -> DocumentService:
+    """Dependency returning a document service bound to the session."""
+
+    return DocumentService(session)
+
+
+def _verify_signature(raw_body: bytes, signature_header: Optional[str], secret: str) -> None:
+    """Validate the request signature using the configured secret."""
+
+    if not signature_header:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing orchestrator signature header",
+        )
+
+    if not signature_header.startswith(SIGNATURE_PREFIX):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid orchestrator signature format",
+        )
+
+    provided_signature = signature_header[len(SIGNATURE_PREFIX) :]
+    expected = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(provided_signature, expected):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid orchestrator signature",
+        )
+
+
+def _handle_document_patch(
+    payload: DocumentPatchPayload,
+    document_service: DocumentService,
+) -> DocumentPatchResult:
+    """Delegate to the document service to apply the patch."""
+
+    return document_service.apply_patch(
+        document_id=payload.document_id,
+        tenant_id=payload.tenant_id,
+        expected_version=payload.document_version,
+        patch_ops=payload.patch,
+        actor_id=payload.actor_id,
+        actor_type=payload.actor_type,
+        change_summary=payload.change_summary,
+        evidence=payload.evidence,
+    )
+
+
+@router.post("/callbacks", status_code=status.HTTP_202_ACCEPTED)
+async def orchestrator_callback(
+    request: Request,
+    event: OrchestratorEvent,
+    document_service: DocumentService = Depends(get_document_service),
+    settings: Settings = Depends(get_settings),
+):
+    """Process webhook callbacks emitted by the AI orchestrator."""
+
+    raw_body = await request.body()
+
+    secret = getattr(settings, "ORCHESTRATOR_WEBHOOK_SECRET", None)
+    if secret:
+        signature = request.headers.get(SIGNATURE_HEADER)
+        _verify_signature(raw_body, signature, secret)
+
+    handler: Optional[DocumentPatchResult] = None
+
+    if event.event == "initialization.completed":
+        document_payload = DocumentPatchPayload.model_validate(event.data)
+        try:
+            handler = _handle_document_patch(document_payload, document_service)
+        except DocumentNotFoundError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+        except DocumentVersionConflictError as exc:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+        except DocumentValidationError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        except DocumentPatchError as exc:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
+    else:
+        logger.info("Received unsupported orchestrator event %s", event.event)
+        return {"status": "ignored", "event": event.event}
+
+    return {
+        "status": "applied",
+        "event": event.event,
+        "document_id": str(handler.document_id),
+        "document_version": handler.version,
+        "content_hash": handler.content_hash,
+    }

--- a/services/api/api/services/__init__.py
+++ b/services/api/api/services/__init__.py
@@ -1,0 +1,19 @@
+"""Service layer utilities for the API gateway."""
+
+from .document_service import (
+    DocumentService,
+    DocumentPatchResult,
+    DocumentNotFoundError,
+    DocumentVersionConflictError,
+    DocumentValidationError,
+    DocumentPatchError,
+)
+
+__all__ = [
+    "DocumentService",
+    "DocumentPatchResult",
+    "DocumentNotFoundError",
+    "DocumentVersionConflictError",
+    "DocumentValidationError",
+    "DocumentPatchError",
+]

--- a/services/api/api/services/document_service.py
+++ b/services/api/api/services/document_service.py
@@ -1,0 +1,176 @@
+"""Document service providing patch application utilities."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from models.document import Document, DocumentVersion
+from odl_sd.schemas import OdlSdDocument
+from odl_sd_patch import PatchValidationError, apply_patch
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentServiceError(Exception):
+    """Base exception for document service errors."""
+
+
+class DocumentNotFoundError(DocumentServiceError):
+    """Raised when a document cannot be found for the provided identifiers."""
+
+
+class DocumentVersionConflictError(DocumentServiceError):
+    """Raised when the requested version does not match the stored version."""
+
+
+class DocumentValidationError(DocumentServiceError):
+    """Raised when a patched document fails validation."""
+
+
+class DocumentPatchError(DocumentServiceError):
+    """Raised when applying a patch to a document fails."""
+
+
+@dataclass
+class DocumentPatchResult:
+    """Details about an applied patch."""
+
+    document_id: uuid.UUID
+    version: int
+    content_hash: str
+
+
+class DocumentService:
+    """Service object encapsulating document mutation operations."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def apply_patch(
+        self,
+        *,
+        document_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        expected_version: int,
+        patch_ops: Iterable[dict],
+        actor_id: Optional[uuid.UUID] = None,
+        actor_type: str = "system",
+        change_summary: Optional[str] = None,
+        evidence: Optional[List[str]] = None,
+    ) -> DocumentPatchResult:
+        """Apply a JSON patch to a document and persist the new version."""
+
+        logger.info(
+            "Applying patch to document %s for tenant %s via document service",
+            document_id,
+            tenant_id,
+        )
+
+        document = (
+            self._session.query(Document)
+            .filter(
+                Document.id == document_id,
+                Document.tenant_id == tenant_id,
+            )
+            .with_for_update()
+            .first()
+        )
+
+        if not document:
+            logger.warning(
+                "Document %s not found for tenant %s while applying orchestrator patch",
+                document_id,
+                tenant_id,
+            )
+            raise DocumentNotFoundError("Document not found")
+
+        if document.current_version != expected_version:
+            logger.error(
+                "Version conflict applying patch to document %s: expected %s got %s",
+                document_id,
+                expected_version,
+                document.current_version,
+            )
+            raise DocumentVersionConflictError(
+                f"Version conflict. Expected {expected_version}, got {document.current_version}"
+            )
+
+        evidence_list = list(evidence or [])
+
+        try:
+            patched_document = apply_patch(
+                document.document_data,
+                list(patch_ops),
+                evidence=evidence_list,
+                dry_run=False,
+                actor=str(actor_id) if actor_id else None,
+            )
+        except PatchValidationError as exc:
+            logger.error("Patch validation error for document %s: %s", document_id, exc)
+            raise DocumentPatchError(str(exc)) from exc
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error applying patch to document %s", document_id)
+            raise DocumentPatchError("Failed to apply patch") from exc
+
+        odl_document = OdlSdDocument.parse_obj(patched_document)
+        validation_result = odl_document.validate_document()
+        if not validation_result.is_valid:
+            logger.error(
+                "Patched document %s failed validation: %s",
+                document_id,
+                validation_result.errors,
+            )
+            raise DocumentValidationError(
+                f"Patched document invalid: {validation_result.errors}"
+            )
+
+        new_version = document.current_version + 1
+        previous_hash = document.content_hash
+        new_hash = odl_document.meta.versioning.content_hash
+        actor_uuid = actor_id or uuid.uuid5(uuid.NAMESPACE_DNS, "originfd-orchestrator")
+
+        document.current_version = new_version
+        document.content_hash = new_hash
+        document.document_data = patched_document
+        document.updated_at = datetime.utcnow()
+
+        version = DocumentVersion(
+            tenant_id=document.tenant_id,
+            document_id=document.id,
+            version_number=new_version,
+            content_hash=new_hash,
+            previous_hash=previous_hash,
+            change_summary=change_summary,
+            patch_operations=list(patch_ops),
+            evidence_uris=evidence_list,
+            created_by=actor_uuid,
+            actor_type=actor_type,
+            document_data=patched_document,
+        )
+
+        try:
+            self._session.add(version)
+            self._session.commit()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception(
+                "Failed to persist new document version for %s", document_id
+            )
+            self._session.rollback()
+            raise DocumentPatchError("Failed to persist document changes") from exc
+
+        logger.info(
+            "Successfully applied patch to document %s, new version %s",
+            document_id,
+            new_version,
+        )
+
+        return DocumentPatchResult(
+            document_id=document.id,
+            version=new_version,
+            content_hash=new_hash,
+        )

--- a/services/api/core/config.py
+++ b/services/api/core/config.py
@@ -114,6 +114,9 @@ class Settings(BaseSettings):
     ORCHESTRATOR_URL: str = Field(
         default="http://localhost:8001", env="ORCHESTRATOR_URL"
     )
+    ORCHESTRATOR_WEBHOOK_SECRET: Optional[str] = Field(
+        default=None, env="ORCHESTRATOR_WEBHOOK_SECRET"
+    )
 
     # Google Cloud
     GOOGLE_CLOUD_PROJECT: Optional[str] = Field(

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -10,7 +10,16 @@ from contextlib import asynccontextmanager
 import uvicorn
 
 # Include core API routers
-from api.routers import alarms, approvals, auth, commerce, documents, health, projects
+from api.routers import (
+    alarms,
+    approvals,
+    auth,
+    commerce,
+    documents,
+    health,
+    orchestrator,
+    projects,
+)
 from core.config import get_settings
 from core.database import get_engine
 from core.logging_config import setup_logging
@@ -138,6 +147,9 @@ app.include_router(documents.router, prefix="/documents", tags=["documents"])
 app.include_router(documents.project_router, prefix="/projects", tags=["documents"])
 app.include_router(simple_components_router, prefix="/components", tags=["components"])
 app.include_router(commerce.router, prefix="/commerce", tags=["commerce"])
+app.include_router(
+    orchestrator.router, prefix="/orchestrator", tags=["orchestrator"]
+)
 
 # app.include_router(component_integration.router, prefix="/component-integration", tags=["component-integration"])
 # app.include_router(suppliers.router, prefix="/suppliers", tags=["suppliers"])

--- a/tests/api/test_orchestrator_callbacks.py
+++ b/tests/api/test_orchestrator_callbacks.py
@@ -1,0 +1,297 @@
+"""Integration tests for the orchestrator webhook router."""
+
+import copy
+import hashlib
+import hmac
+import json
+import os
+import sys
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+API_ROOT = os.path.join(PROJECT_ROOT, "services", "api")
+if API_ROOT not in sys.path:
+    sys.path.insert(0, API_ROOT)
+
+PACKAGES_ROOT = os.path.join(PROJECT_ROOT, "packages", "py")
+if PACKAGES_ROOT not in sys.path:
+    sys.path.insert(0, PACKAGES_ROOT)
+
+from api.routers import orchestrator  # noqa: E402
+from api.services import document_service as document_service_module  # noqa: E402
+from core.config import get_settings  # noqa: E402
+
+
+class FakeQuery:
+    """Minimal query object supporting the interface used by the service."""
+
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *args, **kwargs):  # pragma: no cover - arguments unused
+        return self
+
+    def with_for_update(self):
+        return self
+
+    def first(self):
+        if isinstance(self._result, list):
+            return self._result[0] if self._result else None
+        return self._result
+
+
+class FakeSession:
+    """Simple in-memory session used for orchestrator webhook tests."""
+
+    def __init__(self, document):
+        self.document = document
+        self.added_objects = []
+        self.committed = False
+        self.rolled_back = False
+
+    def query(self, model):
+        document_model = document_service_module.Document
+        version_model = document_service_module.DocumentVersion
+
+        if model is document_model:
+            return FakeQuery(self.document)
+        if model is version_model:
+            return FakeQuery([])
+        return FakeQuery(None)
+
+    def add(self, obj):
+        self.added_objects.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):  # pragma: no cover - defensive
+        self.rolled_back = True
+
+
+@pytest.fixture()
+def sample_document():
+    """Create a minimal document payload used in orchestrator tests."""
+
+    timestamp = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return {
+        "$schema": "https://odl-sd.org/schemas/v4.1/document.json",
+        "schema_version": "4.1",
+        "meta": {
+            "project": "Demo Project",
+            "domain": "PV",
+            "scale": "UTILITY",
+            "units": {"system": "SI"},
+            "timestamps": {"created_at": timestamp, "updated_at": timestamp},
+            "versioning": {
+                "document_version": "1.0.0",
+                "content_hash": "sha256:original",
+            },
+        },
+        "hierarchy": {"sites": [{"id": "site-1", "name": "Baseline"}]},
+        "libraries": {},
+        "instances": [],
+        "connections": [],
+        "analysis": [],
+        "audit": [],
+        "data_management": {},
+    }
+
+
+@pytest.fixture()
+def orchestrator_test_context(sample_document, monkeypatch):
+    """Set up FastAPI test client with stubbed dependencies."""
+
+    app = FastAPI()
+    app.include_router(orchestrator.router, prefix="/orchestrator")
+
+    tenant_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+    actor_id = uuid.uuid4()
+
+    base_document = copy.deepcopy(sample_document)
+
+    class ColumnStub:
+        def __eq__(self, other):  # pragma: no cover - expressions ignored
+            return True
+
+        def __hash__(self):  # pragma: no cover - required for comparisons
+            return hash("column-stub")
+
+    class StubDocument:
+        id = ColumnStub()
+        tenant_id = ColumnStub()
+
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class StubDocumentVersion:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(document_service_module, "Document", StubDocument)
+    monkeypatch.setattr(
+        document_service_module, "DocumentVersion", StubDocumentVersion
+    )
+
+    document = StubDocument(
+        id=document_id,
+        tenant_id=tenant_id,
+        project_name=base_document["meta"]["project"],
+        portfolio_id=None,
+        domain=base_document["meta"]["domain"],
+        scale=base_document["meta"]["scale"],
+        current_version=1,
+        content_hash=base_document["meta"]["versioning"]["content_hash"],
+        document_data=base_document,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        is_active=True,
+    )
+
+    expected_document = copy.deepcopy(base_document)
+    expected_document["hierarchy"]["sites"][0]["name"] = "Updated Site"
+    expected_document["meta"]["versioning"]["content_hash"] = "sha256:newhash"
+
+    def fake_apply_patch(document_data, patch_ops, **kwargs):
+        return copy.deepcopy(expected_document)
+
+    class StubOdlSdDocument:
+        def __init__(self, data):
+            versioning = data["meta"]["versioning"]
+            self.meta = SimpleNamespace(
+                versioning=SimpleNamespace(content_hash=versioning["content_hash"])
+            )
+
+        @classmethod
+        def parse_obj(cls, data):
+            return cls(data)
+
+        def validate_document(self):
+            return SimpleNamespace(is_valid=True, errors=[])
+
+    monkeypatch.setattr(document_service_module, "apply_patch", fake_apply_patch)
+    monkeypatch.setattr(document_service_module, "OdlSdDocument", StubOdlSdDocument)
+
+    fake_session = FakeSession(document)
+    document_service = document_service_module.DocumentService(fake_session)
+
+    secret = "whsec_test"
+
+    app.dependency_overrides[orchestrator.get_document_service] = lambda: document_service
+    app.dependency_overrides[get_settings] = lambda: SimpleNamespace(
+        ORCHESTRATOR_WEBHOOK_SECRET=secret
+    )
+
+    client = TestClient(app)
+
+    return {
+        "client": client,
+        "document": document,
+        "session": fake_session,
+        "expected_document": expected_document,
+        "secret": secret,
+        "tenant_id": tenant_id,
+        "document_id": document_id,
+        "actor_id": actor_id,
+    }
+
+
+def _signed_headers(secret: str, body: str) -> dict[str, str]:
+    signature = hmac.new(secret.encode("utf-8"), body.encode("utf-8"), hashlib.sha256)
+    return {
+        "content-type": "application/json",
+        orchestrator.SIGNATURE_HEADER: f"sha256={signature.hexdigest()}",
+    }
+
+
+def test_initialization_completed_applies_patch(orchestrator_test_context):
+    """The initialization.completed event applies document patches and persists changes."""
+
+    ctx = orchestrator_test_context
+    client = ctx["client"]
+
+    payload = {
+        "event": "initialization.completed",
+        "data": {
+            "document_id": str(ctx["document_id"]),
+            "tenant_id": str(ctx["tenant_id"]),
+            "document_version": ctx["document"].current_version,
+            "patch": [
+                {
+                    "op": "replace",
+                    "path": "/hierarchy/sites/0/name",
+                    "value": "Updated Site",
+                }
+            ],
+            "change_summary": "AI orchestrator initialization adjustments",
+            "evidence": ["s3://bucket/path"],
+            "actor_id": str(ctx["actor_id"]),
+        },
+        "id": str(uuid.uuid4()),
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+
+    body = json.dumps(payload)
+    response = client.post(
+        "/orchestrator/callbacks",
+        data=body,
+        headers=_signed_headers(ctx["secret"], body),
+    )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["status"] == "applied"
+    assert data["document_version"] == ctx["document"].current_version
+    assert ctx["session"].committed is True
+    assert ctx["document"].current_version == 2
+    assert (
+        ctx["document"].document_data["hierarchy"]["sites"][0]["name"]
+        == "Updated Site"
+    )
+    assert len(ctx["session"].added_objects) == 1
+    version = ctx["session"].added_objects[0]
+    assert version.version_number == 2
+    assert version.patch_operations == payload["data"]["patch"]
+    assert version.evidence_uris == payload["data"]["evidence"]
+    assert str(version.created_by) == str(ctx["actor_id"])
+
+
+def test_invalid_signature_rejected(orchestrator_test_context):
+    """Requests with invalid signatures are rejected before processing."""
+
+    ctx = orchestrator_test_context
+    client = ctx["client"]
+
+    payload = {
+        "event": "initialization.completed",
+        "data": {
+            "document_id": str(ctx["document_id"]),
+            "tenant_id": str(ctx["tenant_id"]),
+            "document_version": ctx["document"].current_version,
+            "patch": [],
+        },
+        "id": str(uuid.uuid4()),
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+
+    body = json.dumps(payload)
+    headers = {
+        "content-type": "application/json",
+        orchestrator.SIGNATURE_HEADER: "sha256=invalid",
+    }
+
+    response = client.post("/orchestrator/callbacks", data=body, headers=headers)
+
+    assert response.status_code == 400
+    assert ctx["session"].committed is False
+    assert ctx["document"].current_version == 1


### PR DESCRIPTION
## Summary
- add an orchestrator webhook router that validates signatures and dispatches supported events
- introduce a document service to encapsulate patch application and reuse from orchestrator callbacks
- cover the new webhook flow with integration tests simulating signed callbacks and persistence behaviour

## Testing
- `pytest tests/api/test_orchestrator_callbacks.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0eac04ee08329ace8c1d0b624929d