### PR TITLE
Add lifecycle tables and seed defaults for projects

### DIFF
--- a/services/api/alembic/versions/8d6c0a521db0_create_lifecycle_tables.py
+++ b/services/api/alembic/versions/8d6c0a521db0_create_lifecycle_tables.py
@@ -1,0 +1,255 @@
+"""create lifecycle phase and gate tables
+
+Revision ID: 8d6c0a521db0
+Revises: de1cf7c4075a
+Create Date: 2024-04-08 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "8d6c0a521db0"
+down_revision = "de1cf7c4075a"
+branch_labels = None
+depends_on = None
+
+
+DEFAULT_LIFECYCLE_TEMPLATE = [
+    {
+        "key": "design",
+        "name": "Design",
+        "status": "not_started",
+        "gates": [
+            {"key": "site_assessment", "name": "Site Assessment", "status": "not_started"},
+            {"key": "bom_approval", "name": "BOM Approval", "status": "not_started"},
+        ],
+    },
+    {
+        "key": "procurement",
+        "name": "Procurement",
+        "status": "not_started",
+        "gates": [
+            {
+                "key": "supplier_selection",
+                "name": "Supplier Selection",
+                "status": "not_started",
+            },
+            {
+                "key": "contract_signed",
+                "name": "Contract Signed",
+                "status": "not_started",
+            },
+        ],
+    },
+    {
+        "key": "construction",
+        "name": "Construction",
+        "status": "not_started",
+        "gates": [
+            {"key": "mobilization", "name": "Mobilization", "status": "not_started"},
+        ],
+    },
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lifecycle_phases",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("key", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=50),
+            nullable=False,
+            server_default=sa.text("'not_started'"),
+        ),
+        sa.Column(
+            "position",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.UniqueConstraint(
+            "project_id",
+            "key",
+            name="uq_lifecycle_phases_project_key",
+        ),
+    )
+
+    op.create_table(
+        "lifecycle_gates",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "phase_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("lifecycle_phases.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("key", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=50),
+            nullable=False,
+            server_default=sa.text("'not_started'"),
+        ),
+        sa.Column("due_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "position",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.UniqueConstraint(
+            "phase_id",
+            "key",
+            name="uq_lifecycle_gates_phase_key",
+        ),
+    )
+
+    op.create_index(
+        "ix_lifecycle_phases_project_id",
+        "lifecycle_phases",
+        ["project_id"],
+    )
+    op.create_index(
+        "ix_lifecycle_gates_project_id",
+        "lifecycle_gates",
+        ["project_id"],
+    )
+    op.create_index(
+        "ix_lifecycle_gates_phase_id",
+        "lifecycle_gates",
+        ["phase_id"],
+    )
+
+    conn = op.get_bind()
+    project_ids = [row[0] for row in conn.execute(sa.text("SELECT id FROM projects")).fetchall()]
+
+    if not project_ids:
+        return
+
+    phase_table = sa.table(
+        "lifecycle_phases",
+        sa.column("id", postgresql.UUID(as_uuid=True)),
+        sa.column("project_id", postgresql.UUID(as_uuid=True)),
+        sa.column("key", sa.String()),
+        sa.column("name", sa.String()),
+        sa.column("status", sa.String()),
+        sa.column("position", sa.Integer()),
+    )
+    gate_table = sa.table(
+        "lifecycle_gates",
+        sa.column("id", postgresql.UUID(as_uuid=True)),
+        sa.column("project_id", postgresql.UUID(as_uuid=True)),
+        sa.column("phase_id", postgresql.UUID(as_uuid=True)),
+        sa.column("key", sa.String()),
+        sa.column("name", sa.String()),
+        sa.column("status", sa.String()),
+        sa.column("position", sa.Integer()),
+    )
+
+    phase_rows: List[dict] = []
+    gate_rows: List[dict] = []
+
+    for project_id in project_ids:
+        for phase_index, phase_template in enumerate(DEFAULT_LIFECYCLE_TEMPLATE, start=1):
+            phase_id = uuid.uuid4()
+            phase_rows.append(
+                {
+                    "id": phase_id,
+                    "project_id": project_id,
+                    "key": phase_template["key"],
+                    "name": phase_template["name"],
+                    "status": phase_template.get("status", "not_started"),
+                    "position": phase_index,
+                }
+            )
+
+            for gate_index, gate_template in enumerate(
+                phase_template.get("gates", []), start=1
+            ):
+                gate_rows.append(
+                    {
+                        "id": uuid.uuid4(),
+                        "project_id": project_id,
+                        "phase_id": phase_id,
+                        "key": gate_template["key"],
+                        "name": gate_template["name"],
+                        "status": gate_template.get("status", "not_started"),
+                        "position": gate_index,
+                    }
+                )
+
+    if phase_rows:
+        op.bulk_insert(phase_table, phase_rows)
+    if gate_rows:
+        op.bulk_insert(gate_table, gate_rows)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lifecycle_gates_phase_id", table_name="lifecycle_gates")
+    op.drop_index("ix_lifecycle_gates_project_id", table_name="lifecycle_gates")
+    op.drop_index("ix_lifecycle_phases_project_id", table_name="lifecycle_phases")
+    op.drop_table("lifecycle_gates")
+    op.drop_table("lifecycle_phases")

--- a/services/api/api/routers/projects.py
+++ b/services/api/api/routers/projects.py
@@ -36,6 +36,7 @@ def get_mock_user():
 
 
 import models
+from models.lifecycle import LifecycleGate, LifecyclePhase
 from core.database import SessionDep
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from odl_sd.document_generator import DocumentGenerator
@@ -218,6 +219,93 @@ class ProjectListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+DEFAULT_LIFECYCLE_TEMPLATE = [
+    {
+        "key": "design",
+        "name": "Design",
+        "status": "not_started",
+        "gates": [
+            {"key": "site_assessment", "name": "Site Assessment", "status": "not_started"},
+            {"key": "bom_approval", "name": "BOM Approval", "status": "not_started"},
+        ],
+    },
+    {
+        "key": "procurement",
+        "name": "Procurement",
+        "status": "not_started",
+        "gates": [
+            {
+                "key": "supplier_selection",
+                "name": "Supplier Selection",
+                "status": "not_started",
+            },
+            {
+                "key": "contract_signed",
+                "name": "Contract Signed",
+                "status": "not_started",
+            },
+        ],
+    },
+    {
+        "key": "construction",
+        "name": "Construction",
+        "status": "not_started",
+        "gates": [
+            {"key": "mobilization", "name": "Mobilization", "status": "not_started"},
+        ],
+    },
+]
+
+
+def _seed_project_lifecycle(db: Session, project: models.Project) -> None:
+    """Ensure a project has baseline lifecycle data."""
+
+    if not project.id:
+        return
+
+    has_phases = (
+        db.query(LifecyclePhase)
+        .filter(LifecyclePhase.project_id == project.id)
+        .limit(1)
+        .count()
+    )
+    if has_phases:
+        return
+
+    phases: List[LifecyclePhase] = []
+    for index, phase_template in enumerate(DEFAULT_LIFECYCLE_TEMPLATE, start=1):
+        phase = LifecyclePhase(
+            project=project,
+            key=phase_template["key"],
+            name=phase_template["name"],
+            status=phase_template.get("status", "not_started"),
+            position=index,
+        )
+
+        gates: List[LifecycleGate] = []
+        for gate_index, gate_template in enumerate(
+            phase_template.get("gates", []), start=1
+        ):
+            gate = LifecycleGate(
+                project=project,
+                phase=phase,
+                key=gate_template["key"],
+                name=gate_template["name"],
+                status=gate_template.get("status", "not_started"),
+                position=gate_index,
+            )
+            gates.append(gate)
+
+        if gates:
+            phase.lifecycle_gates = gates
+
+        phases.append(phase)
+
+    if phases:
+        project.lifecycle_phases.extend(phases)
+        db.flush()
 
 
 def _get_project_document_metadata(
@@ -403,6 +491,8 @@ async def create_project(
     try:
         db.add(project)
         db.flush()  # Ensure project ID is available for document linkage
+
+        _seed_project_lifecycle(db, project)
 
         document.portfolio_id = project.id
         db.add(document)

--- a/services/api/models/__init__.py
+++ b/services/api/models/__init__.py
@@ -9,6 +9,7 @@ from .component import Component
 # Complex models with multiple dependencies last
 from .document import Document
 from .inventory_record import InventoryRecord
+from .lifecycle import LifecycleGate, LifecyclePhase
 from .project import Project
 from .supplier import Supplier
 
@@ -26,6 +27,8 @@ __all__ = [
     "TenantMembership",
     "User",
     "Project",
+    "LifecyclePhase",
+    "LifecycleGate",
     "Component",
     "Supplier",
     "InventoryRecord",

--- a/services/api/models/lifecycle.py
+++ b/services/api/models/lifecycle.py
@@ -1,0 +1,77 @@
+"""Lifecycle phase and gate models."""
+
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin, UUIDMixin
+
+
+class LifecyclePhase(Base, UUIDMixin, TimestampMixin):
+    """Represents a workflow phase for a project."""
+
+    __tablename__ = "lifecycle_phases"
+
+    project_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    key = Column(String(64), nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(String, nullable=True)
+    status = Column(String(50), nullable=False, default="not_started")
+    position = Column(Integer, nullable=False, default=0)
+
+    project: "Project" = relationship("Project", back_populates="lifecycle_phases")
+    lifecycle_gates: List["LifecycleGate"] = relationship(
+        "LifecycleGate",
+        back_populates="phase",
+        cascade="all, delete-orphan",
+        order_by="LifecycleGate.position",
+    )
+
+    __table_args__ = (
+        UniqueConstraint("project_id", "key", name="uq_lifecycle_phases_project_key"),
+    )
+
+
+class LifecycleGate(Base, UUIDMixin, TimestampMixin):
+    """Represents a gate/checkpoint within a lifecycle phase."""
+
+    __tablename__ = "lifecycle_gates"
+
+    project_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    phase_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("lifecycle_phases.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    key = Column(String(64), nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(String, nullable=True)
+    status = Column(String(50), nullable=False, default="not_started")
+    due_date = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    position = Column(Integer, nullable=False, default=0)
+
+    project: "Project" = relationship("Project", back_populates="lifecycle_gates")
+    phase: LifecyclePhase = relationship("LifecyclePhase", back_populates="lifecycle_gates")
+
+    __table_args__ = (
+        UniqueConstraint("phase_id", "key", name="uq_lifecycle_gates_phase_key"),
+    )
+
+
+__all__ = ["LifecyclePhase", "LifecycleGate"]

--- a/services/api/models/project.py
+++ b/services/api/models/project.py
@@ -82,6 +82,18 @@ class Project(Base, UUIDMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("documents.id"), nullable=True
     )
 
+    lifecycle_phases = relationship(
+        "LifecyclePhase",
+        back_populates="project",
+        cascade="all, delete-orphan",
+        order_by="LifecyclePhase.position",
+    )
+    lifecycle_gates = relationship(
+        "LifecycleGate",
+        back_populates="project",
+        cascade="all, delete-orphan",
+    )
+
     def can_edit(self, user_id: str) -> bool:
         """Check if a user can edit this project."""
         return str(self.owner_id) == user_id


### PR DESCRIPTION
## Summary
- add dedicated lifecycle phase and gate ORM models with project relationships
- seed default lifecycle data whenever a project is created
- create an Alembic migration to create the new tables and backfill existing projects

## Testing
- `pytest services/api -q` *(fails: pytest configuration requires pytest-cov plugin which is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0eaf4a54883299ffb251f08bb7384