### PR TITLE
Add lifecycle gate approval auditing

### DIFF
--- a/services/api/api/routers/projects.py
+++ b/services/api/api/routers/projects.py
@@ -2,10 +2,11 @@
 models.Project management endpoints.
 """
 
+import copy
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Union, Literal
 
 import httpx
 
@@ -39,6 +40,7 @@ import models
 from core.database import SessionDep
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from odl_sd.document_generator import DocumentGenerator
+from odl_sd_patch.patch import apply_patch
 from pydantic import BaseModel, Field, validator
 from sqlalchemy import and_, or_
 from sqlalchemy.exc import SQLAlchemyError
@@ -66,6 +68,242 @@ from models.project import (  # type: ignore  # circular import friendliness
 
 
 router = APIRouter()
+
+
+ALLOWED_GATE_APPROVER_ROLES = {"admin", "engineer", "project_manager", "approver"}
+
+
+def _create_default_lifecycle() -> Dict[str, Any]:
+    """Construct the default lifecycle template for new projects."""
+
+    return {
+        "phases": [
+            {
+                "id": "design",
+                "name": "Design",
+                "status": "not_started",
+                "gates": [
+                    {
+                        "id": "site_assessment",
+                        "name": "Site Assessment",
+                        "status": "pending",
+                        "approved_by": None,
+                        "approved_at": None,
+                        "updated_at": None,
+                        "updated_by": None,
+                        "notes": None,
+                    },
+                    {
+                        "id": "bom_approval",
+                        "name": "BOM Approval",
+                        "status": "pending",
+                        "approved_by": None,
+                        "approved_at": None,
+                        "updated_at": None,
+                        "updated_by": None,
+                        "notes": None,
+                    },
+                ],
+            },
+            {
+                "id": "procurement",
+                "name": "Procurement",
+                "status": "upcoming",
+                "gates": [
+                    {
+                        "id": "supplier_selection",
+                        "name": "Supplier Selection",
+                        "status": "pending",
+                        "approved_by": None,
+                        "approved_at": None,
+                        "updated_at": None,
+                        "updated_by": None,
+                        "notes": None,
+                    },
+                    {
+                        "id": "contract_signed",
+                        "name": "Contract Signed",
+                        "status": "pending",
+                        "approved_by": None,
+                        "approved_at": None,
+                        "updated_at": None,
+                        "updated_by": None,
+                        "notes": None,
+                    },
+                ],
+            },
+            {
+                "id": "construction",
+                "name": "Construction",
+                "status": "upcoming",
+                "gates": [
+                    {
+                        "id": "mobilization",
+                        "name": "Mobilization",
+                        "status": "pending",
+                        "approved_by": None,
+                        "approved_at": None,
+                        "updated_at": None,
+                        "updated_by": None,
+                        "notes": None,
+                    }
+                ],
+            },
+        ]
+    }
+
+
+PROJECT_LIFECYCLE_STATE: Dict[str, Dict[str, Any]] = {}
+
+
+def _ensure_lifecycle(project_id: str) -> Dict[str, Any]:
+    """Return existing lifecycle data for a project or initialize it."""
+
+    lifecycle = PROJECT_LIFECYCLE_STATE.get(project_id)
+    if lifecycle is None:
+        lifecycle = _create_default_lifecycle()
+        PROJECT_LIFECYCLE_STATE[project_id] = lifecycle
+    return lifecycle
+
+
+def _get_project_or_404(db: Session, project_id: str) -> models.Project:
+    """Fetch a project by ID, raising a 404 if it does not exist."""
+
+    try:
+        project_uuid = uuid.UUID(str(project_id))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found",
+        ) from exc
+
+    project: Optional[models.Project] = None
+    get_method = getattr(db, "get", None)
+    if callable(get_method):  # pragma: no branch - attribute presence check
+        project = get_method(models.Project, project_uuid)
+
+    if project is None and hasattr(db, "query"):
+        project = (
+            db.query(models.Project)
+            .filter(models.Project.id == project_uuid)
+            .first()
+        )
+
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found",
+        )
+
+    return project
+
+
+def _get_project_document(db: Session, project: models.Project) -> Optional[models.Document]:
+    """Fetch the primary document associated with a project if available."""
+
+    document_id = getattr(project, "primary_document_id", None)
+    if not document_id:
+        return None
+
+    try:
+        document_uuid = uuid.UUID(str(document_id))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+    get_method = getattr(db, "get", None)
+    if callable(get_method):
+        document = get_method(models.Document, document_uuid)
+        if document is not None:
+            return document
+
+    if hasattr(db, "query"):
+        document = (
+            db.query(models.Document)
+            .filter(models.Document.id == document_uuid)
+            .first()
+        )
+        if document is not None:
+            return document
+
+    # Support simple in-memory test sessions
+    documents = getattr(db, "documents", None)
+    if isinstance(documents, list):
+        for doc in documents:
+            if str(getattr(doc, "id", "")) == str(document_uuid):
+                return doc
+    return None
+
+
+def _recalculate_progress(lifecycle: Dict[str, Any]) -> Dict[str, Union[int, str]]:
+    """Compute display status and completion percentage from lifecycle data."""
+
+    phases = lifecycle.get("phases", [])
+    gates: List[Dict[str, Any]] = [
+        gate
+        for phase in phases
+        for gate in phase.get("gates", [])
+        if isinstance(gate, dict)
+    ]
+
+    total_gates = len(gates)
+    completed_gates = sum(
+        1 for gate in gates if gate.get("status") in {"approved", "completed"}
+    )
+
+    completion_percentage = (
+        int(round((completed_gates / total_gates) * 100)) if total_gates else 0
+    )
+
+    if total_gates and completed_gates == total_gates:
+        display_status = "gates_completed"
+    elif completed_gates:
+        display_status = "in_gate_review"
+    else:
+        display_status = "awaiting_approvals"
+
+    return {
+        "display_status": display_status,
+        "completion_percentage": completion_percentage,
+    }
+
+
+def _persist_gate_state(
+    db: Session,
+    project: models.Project,
+    lifecycle: Dict[str, Any],
+    actor_id: str,
+) -> None:
+    """Write lifecycle gate state to the project's primary document audit log."""
+
+    document = _get_project_document(db, project)
+    if document is None:
+        return
+
+    doc_data: Dict[str, Any] = document.document_data or {}
+
+    try:
+        patched_doc = apply_patch(
+            doc_data,
+            [{"op": "add", "path": "/lifecycle", "value": lifecycle}],
+            actor=str(actor_id),
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logging.getLogger(__name__).warning(
+            "Failed to persist gate state to document audit: %s", exc
+        )
+        return
+
+    document.document_data = patched_doc
+    try:
+        document.content_hash = (
+            patched_doc.get("meta", {})
+            .get("versioning", {})
+            .get("content_hash", document.content_hash)
+        )
+    except AttributeError:  # pragma: no cover - defensive
+        pass
+    if hasattr(document, "updated_at"):
+        document.updated_at = datetime.now(timezone.utc)
 
 
 class ProjectCreateRequest(BaseModel):
@@ -218,6 +456,26 @@ class ProjectListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+class GateStatusUpdateRequest(BaseModel):
+    """Payload for updating a lifecycle gate status."""
+
+    status: Literal["pending", "in_review", "approved", "rejected", "blocked"]
+    notes: Optional[str] = Field(None, max_length=500)
+
+
+class GateStatusResponse(BaseModel):
+    """Response model after updating a lifecycle gate."""
+
+    gate_id: str
+    phase_id: str
+    status: str
+    approved_by: Optional[str]
+    approved_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    updated_by: Optional[str]
+    notes: Optional[str]
 
 
 def _get_project_document_metadata(
@@ -436,6 +694,8 @@ async def create_project(
     db.refresh(document)
 
     document_metadata = _build_document_metadata(document)
+
+    _ensure_lifecycle(str(project.id))
 
     # Submit initialization task to AI orchestrator
     settings = get_settings()
@@ -776,64 +1036,121 @@ async def get_project_lifecycle(
     project_id: str,
     current_user: dict = Depends(get_current_user),
 ):
-    """Return lifecycle phases and gate checklist for a project.
+    """Return lifecycle phases and gate checklist for a project."""
 
-    This temporary implementation returns mock data and uses the
-    orchestrator to annotate gates with potential bottlenecks.
-    """
-
-    # In a real implementation this data would come from the database
-    # or project documents. We provide a minimal structure for now.
-    lifecycle_data = {
-        "phases": [
-            {
-                "id": "design",
-                "name": "Design",
-                "status": "completed",
-                "gates": [
-                    {
-                        "id": "site_assessment",
-                        "name": "Site Assessment",
-                        "status": "completed",
-                    },
-                    {
-                        "id": "bom_approval",
-                        "name": "BOM Approval",
-                        "status": "completed",
-                    },
-                ],
-            },
-            {
-                "id": "procurement",
-                "name": "Procurement",
-                "status": "current",
-                "gates": [
-                    {
-                        "id": "supplier_selection",
-                        "name": "Supplier Selection",
-                        "status": "blocked",
-                    },
-                    {
-                        "id": "contract_signed",
-                        "name": "Contract Signed",
-                        "status": "pending",
-                        "due_date": (datetime.utcnow() - timedelta(days=3)).isoformat(),
-                    },
-                ],
-            },
-            {
-                "id": "construction",
-                "name": "Construction",
-                "status": "upcoming",
-                "gates": [
-                    {"id": "mobilization", "name": "Mobilization", "status": "pending"}
-                ],
-            },
-        ]
-    }
+    lifecycle_state = copy.deepcopy(_ensure_lifecycle(project_id))
 
     # Use orchestrator to detect bottlenecks and annotate gates
-    bottlenecks = AgentManager.detect_bottlenecks(lifecycle_data)
-    lifecycle_data["bottlenecks"] = bottlenecks
+    bottlenecks = AgentManager.detect_bottlenecks(lifecycle_state)
+    lifecycle_state["bottlenecks"] = bottlenecks
 
-    return lifecycle_data
+    return lifecycle_state
+
+
+@router.post(
+    "/{project_id}/lifecycle/gates/{gate_id}/status",
+    response_model=GateStatusResponse,
+)
+async def update_lifecycle_gate_status(
+    project_id: str,
+    gate_id: str,
+    request: GateStatusUpdateRequest,
+    db: Session = Depends(SessionDep),
+    current_user: dict = Depends(get_current_user),
+):
+    """Update the status of a lifecycle gate with RBAC and auditing."""
+
+    user_roles = {
+        str(role).lower() for role in current_user.get("roles", []) if role is not None
+    }
+    if not user_roles.intersection(ALLOWED_GATE_APPROVER_ROLES):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not permitted to approve lifecycle gates",
+        )
+
+    project = _get_project_or_404(db, project_id)
+    project_id_str = str(project.id)
+    lifecycle = _ensure_lifecycle(project_id_str)
+
+    target_gate: Optional[Dict[str, Any]] = None
+    target_phase_id: Optional[str] = None
+    for phase in lifecycle.get("phases", []):
+        for gate in phase.get("gates", []):
+            if gate.get("id") == gate_id:
+                target_gate = gate
+                target_phase_id = phase.get("id")
+                break
+        if target_gate:
+            break
+
+    if target_gate is None or target_phase_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Lifecycle gate not found",
+        )
+
+    raw_actor_id = current_user.get("id")
+    if not raw_actor_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current user identifier missing",
+        )
+    actor_id = str(raw_actor_id)
+    now = datetime.now(timezone.utc)
+    iso_now = now.isoformat()
+
+    target_gate["status"] = request.status
+    target_gate["updated_at"] = iso_now
+    target_gate["updated_by"] = actor_id
+
+    if request.notes is not None:
+        target_gate["notes"] = request.notes
+
+    if request.status == "approved":
+        target_gate["approved_by"] = actor_id
+        target_gate["approved_at"] = iso_now
+    else:
+        target_gate["approved_by"] = actor_id
+        target_gate["approved_at"] = None
+
+    progress = _recalculate_progress(lifecycle)
+    project.display_status = str(progress["display_status"])
+    project.completion_percentage = int(progress["completion_percentage"])
+    project.updated_at = now
+
+    _persist_gate_state(db, project, lifecycle, actor_id)
+
+    try:
+        db.commit()
+    except SQLAlchemyError as exc:  # pragma: no cover - defensive
+        db.rollback()
+        logging.getLogger(__name__).exception("Failed to update lifecycle gate: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update lifecycle gate",
+        ) from exc
+
+    db.refresh(project)
+
+    approved_at_value = target_gate.get("approved_at")
+    updated_at_value = target_gate.get("updated_at")
+
+    return GateStatusResponse(
+        gate_id=gate_id,
+        phase_id=target_phase_id,
+        status=target_gate.get("status", "pending"),
+        approved_by=target_gate.get("approved_by"),
+        approved_at=(
+            datetime.fromisoformat(approved_at_value)
+            if isinstance(approved_at_value, str)
+            else None
+        ),
+        updated_at=(
+            datetime.fromisoformat(updated_at_value)
+            if isinstance(updated_at_value, str)
+            else None
+        ),
+        updated_by=target_gate.get("updated_by"),
+        notes=target_gate.get("notes"),
+    )

--- a/tests/api/projects/test_gate_approvals.py
+++ b/tests/api/projects/test_gate_approvals.py
@@ -1,0 +1,215 @@
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+API_ROOT = os.path.join(PROJECT_ROOT, "services", "api")
+if API_ROOT not in sys.path:
+    sys.path.insert(0, API_ROOT)
+
+PACKAGES_ROOT = os.path.join(PROJECT_ROOT, "packages", "py")
+if PACKAGES_ROOT not in sys.path:
+    sys.path.insert(0, PACKAGES_ROOT)
+
+from api.routers import projects  # noqa: E402
+from core.database import SessionDep  # noqa: E402
+import models  # noqa: E402
+from models.project import (  # noqa: E402
+    ProjectDomain,
+    ProjectScale,
+    ProjectStatus,
+)
+
+
+class FakeSession:
+    """In-memory session to validate gate approval behaviour."""
+
+    def __init__(self, project: models.Project, document: models.Document):
+        self._projects = {project.id: project}
+        self.documents = [document]
+        self.committed = False
+        self.rolled_back = False
+
+    def get(self, model, ident):  # pragma: no cover - exercised in tests
+        if model is models.Project:
+            key = ident if isinstance(ident, uuid.UUID) else uuid.UUID(str(ident))
+            return self._projects.get(key)
+        if model is models.Document:
+            key = ident if isinstance(ident, uuid.UUID) else uuid.UUID(str(ident))
+            for document in self.documents:
+                if document.id == key:
+                    return document
+        return None
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):  # pragma: no cover - defensive
+        self.rolled_back = True
+
+    def refresh(self, obj):  # pragma: no cover - compatibility no-op
+        return obj
+
+
+class StubProject:
+    def __init__(self, user_id: uuid.UUID):
+        now = datetime.now(timezone.utc)
+        self.id = uuid.uuid4()
+        self.name = "Gate Approval Project"
+        self.description = "Lifecycle approval checks"
+        self.domain = ProjectDomain.PV
+        self.scale = ProjectScale.UTILITY
+        self.status = ProjectStatus.DRAFT
+        self.owner_id = user_id
+        self.display_status = "draft"
+        self.completion_percentage = 0
+        self.created_at = now
+        self.updated_at = now
+        self.primary_document_id = None
+
+    def can_edit(self, user_id: str) -> bool:  # pragma: no cover - simple stub
+        return True
+
+
+class StubDocument:
+    def __init__(self, project: StubProject):
+        now = datetime.now(timezone.utc)
+        self.id = uuid.uuid4()
+        self.tenant_id = uuid.uuid4()
+        self.project_name = project.name
+        self.domain = project.domain.value
+        self.scale = project.scale.value
+        self.current_version = 1
+        self.content_hash = "sha256:" + "0" * 64
+        self.document_data = {
+            "meta": {
+                "versioning": {
+                    "document_version": "4.1.0",
+                    "content_hash": self.content_hash,
+                }
+            },
+            "audit": [],
+        }
+        self.created_at = now
+        self.updated_at = now
+
+
+def _build_project_and_document(user_id: uuid.UUID):
+    project = StubProject(user_id)
+    document = StubDocument(project)
+    project.primary_document_id = document.id
+    return project, document
+
+
+@pytest.fixture()
+def make_client():
+    def _make(roles: list[str]):
+        projects.PROJECT_LIFECYCLE_STATE.clear()
+
+        user_id = uuid.uuid4()
+        project, document = _build_project_and_document(user_id)
+
+        app = FastAPI()
+        app.include_router(projects.router, prefix="/projects")
+
+        fake_session = FakeSession(project, document)
+        app.dependency_overrides[SessionDep] = lambda: fake_session
+
+        tenant_id = uuid.uuid4()
+        current_user = {
+            "id": str(user_id),
+            "email": "approver@example.com",
+            "tenant_id": str(tenant_id),
+            "roles": roles,
+        }
+        app.dependency_overrides[projects.get_current_user] = lambda: current_user
+
+        client = TestClient(app)
+
+        projects._ensure_lifecycle(str(project.id))
+
+        return SimpleNamespace(
+            client=client,
+            session=fake_session,
+            project=project,
+            document=document,
+            user_id=user_id,
+        )
+
+    return _make
+
+
+def _find_gate(project_id: str, gate_id: str):
+    lifecycle = projects.PROJECT_LIFECYCLE_STATE.get(project_id, {})
+    for phase in lifecycle.get("phases", []):
+        for gate in phase.get("gates", []):
+            if gate.get("id") == gate_id:
+                return gate
+    raise AssertionError(f"Gate {gate_id} not found for project {project_id}")
+
+
+def test_gate_approval_records_audit_and_progress(make_client):
+    setup = make_client(["approver"])
+    gate_id = "site_assessment"
+    project_id = str(setup.project.id)
+
+    response = setup.client.post(
+        f"/projects/{project_id}/lifecycle/gates/{gate_id}/status",
+        json={"status": "approved", "notes": "Ready to proceed"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "approved"
+    assert payload["phase_id"] == "design"
+    assert payload["approved_by"] == str(setup.user_id)
+    assert payload["notes"] == "Ready to proceed"
+    approved_at = payload["approved_at"]
+    updated_at = payload["updated_at"]
+    assert approved_at is not None
+    assert updated_at is not None
+    datetime.fromisoformat(approved_at.replace("Z", "+00:00"))
+    datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+
+    gate_state = _find_gate(project_id, gate_id)
+    assert gate_state["status"] == "approved"
+    assert gate_state["approved_by"] == str(setup.user_id)
+    assert gate_state["notes"] == "Ready to proceed"
+
+    assert setup.project.display_status == "in_gate_review"
+    assert setup.project.completion_percentage == 20
+
+    audit_log = setup.document.document_data.get("audit", [])
+    assert audit_log, "Expected audit entry to be created"
+    assert audit_log[-1]["actor"] == str(setup.user_id)
+    assert audit_log[-1]["details"]["patch_operations"] == 1
+
+    assert setup.session.committed is True
+
+
+def test_gate_approval_requires_authorized_role(make_client):
+    setup = make_client(["viewer"])
+    project_id = str(setup.project.id)
+
+    response = setup.client.post(
+        f"/projects/{project_id}/lifecycle/gates/site_assessment/status",
+        json={"status": "approved"},
+    )
+
+    assert response.status_code == 403
+
+    gate_state = _find_gate(project_id, "site_assessment")
+    assert gate_state["status"] == "pending"
+    assert setup.project.display_status == "draft"
+    assert setup.project.completion_percentage == 0
+    assert setup.document.document_data.get("audit", []) == []
+    assert setup.session.committed is False


### PR DESCRIPTION
## Summary
- implement lifecycle gate lifecycle tracking with audit logging and project progress recalculation
- add RBAC-protected gate approval endpoint wiring updates into project display status
- cover approval success and forbidden scenarios with new pytest module

## Testing
- pytest tests/api/projects/test_gate_approvals.py

------
https://chatgpt.com/codex/tasks/task_e_68d0eb07632c83299025cd70f2c0cea2