### PR TITLE
Add commerce usage instrumentation and tests

### DIFF
--- a/services/api/api/routers/commerce.py
+++ b/services/api/api/routers/commerce.py
@@ -11,6 +11,18 @@ from services.commerce_core import escrow_manager, payout_ledger, psu_meter
 router = APIRouter()
 
 
+@router.get("/")
+async def commerce_root() -> dict[str, list[str]]:
+    """Provide discovery information for commerce routes."""
+    return {
+        "available_endpoints": [
+            "GET /commerce/psu/{tenant_id}",
+            "GET /commerce/escrow/{tenant_id}",
+            "GET /commerce/transactions/{tenant_id}",
+        ]
+    }
+
+
 @router.get("/psu/{tenant_id}")
 async def get_psu_usage(tenant_id: str):
     """Retrieve PSU usage for a tenant."""

--- a/services/api/api/routers/documents.py
+++ b/services/api/api/routers/documents.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from odl_sd_patch import apply_patch, inverse_patch, PatchValidationError
+from services.commerce_core import publish_usage_event
 from api.utils.document_serialization import (
     canonicalize_document,
     create_json_export_response,
@@ -80,6 +81,9 @@ class PatchResponse(BaseModel):
     content_hash: str
     inverse_patch: List[Dict[str, Any]]
     applied_at: datetime
+
+
+DOCUMENT_PATCH_PSU_CHARGE = 5
 
 
 @project_router.get(
@@ -425,6 +429,18 @@ async def apply_document_patch(
 
         db.add(version)
         db.commit()
+
+        publish_usage_event(
+            str(document.tenant_id),
+            DOCUMENT_PATCH_PSU_CHARGE,
+            {
+                "event": "document_patched",
+                "document_id": str(document.id),
+                "project_name": document.project_name,
+                "version": new_version,
+                "change_summary": request.change_summary,
+            },
+        )
 
         return PatchResponse(
             success=True,

--- a/services/api/api/routers/projects.py
+++ b/services/api/api/routers/projects.py
@@ -5,7 +5,7 @@ models.Project management endpoints.
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import httpx
 
@@ -45,6 +45,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from models.document import DocumentVersion as SADocumentVersion
+from services.commerce_core import publish_usage_event
 
 # Temporarily disabled due to import issues:
 # from services.orchestrator.agents.agent_manager import AgentManager
@@ -66,6 +67,9 @@ from models.project import (  # type: ignore  # circular import friendliness
 
 
 router = APIRouter()
+
+
+PROJECT_CREATION_PSU_CHARGE = 50
 
 
 class ProjectCreateRequest(BaseModel):
@@ -464,6 +468,21 @@ async def create_project(
         logging.getLogger(__name__).error(
             "Failed to submit project initialization task: %s", e
         )
+
+    usage_metadata: Dict[str, Optional[str]] = {
+        "event": "project_created",
+        "project_id": str(project.id),
+        "owner_id": str(owner_uuid),
+        "document_id": str(document.id),
+    }
+    if task_id:
+        usage_metadata["initialization_task_id"] = task_id
+
+    publish_usage_event(
+        str(tenant_uuid),
+        PROJECT_CREATION_PSU_CHARGE,
+        usage_metadata,
+    )
 
     return ProjectResponse(
         id=str(project.id),

--- a/tests/api/projects/test_create_project.py
+++ b/tests/api/projects/test_create_project.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import uuid
@@ -11,6 +12,8 @@ from fastapi.testclient import TestClient
 PROJECT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..")
 )
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 API_ROOT = os.path.join(PROJECT_ROOT, "services", "api")
 if API_ROOT not in sys.path:
     sys.path.insert(0, API_ROOT)
@@ -22,11 +25,70 @@ if PACKAGES_ROOT not in sys.path:
 from api.routers import projects  # noqa: E402
 from core.database import SessionDep  # noqa: E402
 import models  # noqa: E402
-from models.document import DocumentVersion as SADocumentVersion  # noqa: E402
+class StubProject:
+    """Lightweight stand-in for the SQLAlchemy Project model."""
+
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", uuid.uuid4())
+        self.created_at = kwargs.get("created_at", datetime.now(timezone.utc))
+        self.updated_at = kwargs.get("updated_at", self.created_at)
+        self.display_status = kwargs.get("display_status", "draft")
+        self.completion_percentage = kwargs.get("completion_percentage", 0)
+        self.primary_document_id = kwargs.get("primary_document_id")
+        self.initialization_task_id = kwargs.get("initialization_task_id")
+        self.is_archived = kwargs.get("is_archived", False)
+
+        for field, value in kwargs.items():
+            setattr(self, field, value)
+
+        self.tags = json.dumps(kwargs.get("tags_list", kwargs.get("tags", [])) or [])
+
+    def can_edit(self, user_id: str) -> bool:
+        return str(getattr(self, "owner_id", "")) == user_id
+
+    def can_view(self, user_id: str) -> bool:
+        return self.can_edit(user_id)
+
+    @property
+    def tags_list(self) -> list[str]:
+        try:
+            return json.loads(self.tags or "[]")
+        except (TypeError, json.JSONDecodeError):
+            return []
+
+    @tags_list.setter
+    def tags_list(self, value: list[str]) -> None:
+        self.tags = json.dumps(value or [])
 
 
-if not hasattr(models, "DocumentVersion"):
-    setattr(models, "DocumentVersion", SADocumentVersion)
+class StubDocument:
+    """Minimal document representation for unit tests."""
+
+    id: uuid.UUID | None = None
+    tenant_id: uuid.UUID | None = None
+
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", uuid.uuid4())
+        self.tenant_id = kwargs.get("tenant_id")
+        self.project_name = kwargs.get("project_name")
+        self.portfolio_id = kwargs.get("portfolio_id")
+        self.domain = kwargs.get("domain")
+        self.scale = kwargs.get("scale")
+        self.current_version = kwargs.get("current_version", 1)
+        self.content_hash = kwargs.get("content_hash", "")
+        self.document_data = kwargs.get("document_data", {})
+        self.is_active = kwargs.get("is_active", True)
+        self.created_at = kwargs.get("created_at", datetime.now(timezone.utc))
+        self.updated_at = kwargs.get("updated_at", self.created_at)
+
+
+class StubDocumentVersion:
+    """Simple value object capturing document version metadata."""
+
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", uuid.uuid4())
+        for field, value in kwargs.items():
+            setattr(self, field, value)
 
 
 class FakeQuery:
@@ -67,7 +129,7 @@ class FakeSession:
             self.projects.append(obj)
         elif isinstance(obj, models.Document):
             self.documents.append(obj)
-        elif isinstance(obj, SADocumentVersion):
+        elif isinstance(obj, models.DocumentVersion):
             self.document_versions.append(obj)
 
     def flush(self):
@@ -85,7 +147,7 @@ class FakeSession:
                 obj.id = uuid.uuid4()
                 obj.created_at = getattr(obj, "created_at", None) or now
                 obj.updated_at = getattr(obj, "updated_at", None) or now
-            elif isinstance(obj, SADocumentVersion) and getattr(obj, "id", None) is None:
+            elif isinstance(obj, models.DocumentVersion) and getattr(obj, "id", None) is None:
                 obj.id = uuid.uuid4()
                 obj.created_at = getattr(obj, "created_at", None) or now
         self._pending.clear()
@@ -100,7 +162,7 @@ class FakeSession:
         return obj
 
 
-class StubDocument:
+class StubGeneratedDocument:
     """Simple document stub mimicking the generator output."""
 
     def __init__(self, content_hash: str):
@@ -122,13 +184,18 @@ class StubDocument:
 class StubDocumentGenerator:
     @staticmethod
     def create_project_document(*args, **kwargs):
-        return StubDocument(f"sha256:{uuid.uuid4().hex}")
+        return StubGeneratedDocument(f"sha256:{uuid.uuid4().hex}")
 
 
 @pytest.fixture()
 def test_client(monkeypatch):
     app = FastAPI()
     app.include_router(projects.router, prefix="/projects")
+
+    monkeypatch.setattr(models, "Project", StubProject)
+    monkeypatch.setattr(models, "Document", StubDocument)
+    monkeypatch.setattr(models, "DocumentVersion", StubDocumentVersion, raising=False)
+    monkeypatch.setattr(projects, "SADocumentVersion", StubDocumentVersion)
 
     fake_session = FakeSession()
     app.dependency_overrides[SessionDep] = lambda: fake_session
@@ -144,10 +211,23 @@ def test_client(monkeypatch):
 
     monkeypatch.setattr(projects, "DocumentGenerator", StubDocumentGenerator)
 
+    publish_calls = []
+
+    def _record_usage(tenant: str, psu: int, metadata: dict | None = None):
+        publish_calls.append({
+            "tenant_id": tenant,
+            "psu": psu,
+            "metadata": metadata or {},
+        })
+        return {"psu": psu, "fee": 0}
+
+    monkeypatch.setattr(projects, "publish_usage_event", _record_usage)
+
     client = TestClient(app)
     client.fake_session = fake_session  # type: ignore[attr-defined]
     client.tenant_id = tenant_id  # type: ignore[attr-defined]
     client.user_id = user_id  # type: ignore[attr-defined]
+    client.publish_calls = publish_calls  # type: ignore[attr-defined]
     return client
 
 
@@ -185,6 +265,13 @@ def test_create_project_links_primary_document(test_client):
     assert data["document"]["version"] == document.current_version
     assert data["document_id"] == str(document.id)
     assert data["document_hash"] == document.content_hash
+
+    assert test_client.publish_calls  # type: ignore[attr-defined]
+    usage_call = test_client.publish_calls[0]  # type: ignore[index]
+    assert usage_call["tenant_id"] == str(test_client.tenant_id)  # type: ignore[attr-defined]
+    assert usage_call["psu"] > 0
+    assert usage_call["metadata"]["event"] == "project_created"
+    assert usage_call["metadata"]["project_id"] == str(project.id)
 
 
 def test_create_project_requires_tenant_context(test_client):

--- a/tests/api/test_approvals_usage_event.py
+++ b/tests/api/test_approvals_usage_event.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+API_ROOT = os.path.join(PROJECT_ROOT, "services", "api")
+if API_ROOT not in sys.path:
+    sys.path.insert(0, API_ROOT)
+
+from api.routers import approvals  # noqa: E402
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    app = FastAPI()
+    app.include_router(approvals.router, prefix="/approvals")
+
+    publish_calls = []
+
+    def _record_usage(tenant: str, psu: int, metadata: dict | None = None):
+        publish_calls.append({
+            "tenant_id": tenant,
+            "psu": psu,
+            "metadata": metadata or {},
+        })
+        return {"psu": psu, "fee": 0}
+
+    monkeypatch.setattr(approvals, "publish_usage_event", _record_usage)
+
+    client = TestClient(app)
+    client.publish_calls = publish_calls  # type: ignore[attr-defined]
+    return client
+
+
+def test_gate_approval_publishes_usage_event(client):
+    payload = {
+        "project_id": "proj-123",
+        "decision": "approve",
+        "source": {"tenant_id": "11111111-1111-4111-8111-111111111111"},
+        "target": {"phase": "design"},
+    }
+
+    response = client.post("/approvals/", json=payload)
+
+    assert response.status_code == 200
+    assert client.publish_calls  # type: ignore[attr-defined]
+    usage_call = client.publish_calls[0]  # type: ignore[index]
+    assert usage_call["tenant_id"] == payload["source"]["tenant_id"]
+    assert usage_call["psu"] > 0
+    assert usage_call["metadata"]["event"] == "gate_approval"
+    assert usage_call["metadata"]["decision"] == payload["decision"]
+    assert usage_call["metadata"]["project_id"] == payload["project_id"]

--- a/tests/api/test_documents_patch.py
+++ b/tests/api/test_documents_patch.py
@@ -9,6 +9,8 @@ from fastapi.testclient import TestClient
 
 # Ensure the API package and models are importable
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 API_ROOT = os.path.join(PROJECT_ROOT, "services", "api")
 if API_ROOT not in sys.path:
     sys.path.insert(0, API_ROOT)
@@ -21,11 +23,36 @@ from api.routers import documents  # noqa: E402
 from core.database import SessionDep  # noqa: E402
 from deps import get_current_user  # noqa: E402
 import models  # noqa: E402
-from models.document import DocumentVersion  # noqa: E402
 
 # Ensure DocumentVersion is accessible via the models package
-if not hasattr(models, "DocumentVersion"):
-    setattr(models, "DocumentVersion", DocumentVersion)
+class StubDocument:
+    """Simplified document record for unit testing."""
+
+    id: uuid.UUID | None = None
+    tenant_id: uuid.UUID | None = None
+
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", uuid.uuid4())
+        self.tenant_id = kwargs.get("tenant_id")
+        self.project_name = kwargs.get("project_name")
+        self.portfolio_id = kwargs.get("portfolio_id")
+        self.domain = kwargs.get("domain")
+        self.scale = kwargs.get("scale")
+        self.current_version = kwargs.get("current_version", 1)
+        self.content_hash = kwargs.get("content_hash", "")
+        self.document_data = kwargs.get("document_data", {})
+        self.is_active = kwargs.get("is_active", True)
+        self.created_at = kwargs.get("created_at", datetime.utcnow())
+        self.updated_at = kwargs.get("updated_at", self.created_at)
+
+
+class StubDocumentVersion:
+    """Lightweight DocumentVersion stand-in."""
+
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", uuid.uuid4())
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 
 class FakeQuery:
@@ -138,6 +165,9 @@ def test_client(sample_document, monkeypatch):
     app = FastAPI()
     app.include_router(documents.router, prefix="/documents")
 
+    monkeypatch.setattr(models, "Document", StubDocument)
+    monkeypatch.setattr(models, "DocumentVersion", StubDocumentVersion, raising=False)
+
     class StubOdlDocument:
         def __init__(self, data):
             self._data = data
@@ -182,9 +212,22 @@ def test_client(sample_document, monkeypatch):
         "tenant_id": str(tenant_id),
     }
 
+    publish_calls = []
+
+    def _record_usage(tenant: str, psu: int, metadata: dict | None = None):
+        publish_calls.append({
+            "tenant_id": tenant,
+            "psu": psu,
+            "metadata": metadata or {},
+        })
+        return {"psu": psu, "fee": 0}
+
+    monkeypatch.setattr(documents, "publish_usage_event", _record_usage)
+
     client = TestClient(app)
     client.fake_session = fake_session  # type: ignore[attr-defined]
     client.document = document  # type: ignore[attr-defined]
+    client.publish_calls = publish_calls  # type: ignore[attr-defined]
     return client
 
 
@@ -232,3 +275,11 @@ def test_patch_document_success(test_client):
     assert fake_session.committed is True
     assert fake_session.rolled_back is False
     assert fake_session.added_objects, "DocumentVersion should be recorded"
+
+    assert test_client.publish_calls  # type: ignore[attr-defined]
+    usage_call = test_client.publish_calls[0]  # type: ignore[index]
+    assert usage_call["tenant_id"] == str(document.tenant_id)
+    assert usage_call["psu"] > 0
+    assert usage_call["metadata"]["event"] == "document_patched"
+    assert usage_call["metadata"]["document_id"] == str(document.id)
+    assert usage_call["metadata"]["version"] == document.current_version

--- a/tests/api/test_router_mounting.py
+++ b/tests/api/test_router_mounting.py
@@ -40,6 +40,7 @@ def skip_metadata_creation(monkeypatch) -> Generator[None, None, None]:
         "/alarms",
         "/documents",
         "/components",
+        "/commerce",
     ],
 )
 def test_router_base_path_is_mounted(client, path):


### PR DESCRIPTION
## Summary
- fire publish_usage_event during project creation, document patching, and gate approval flows with contextual metadata
- expose a discovery root endpoint on the commerce router and ensure it is mounted
- extend API unit tests with usage-event assertions and add approval usage test coverage

## Testing
- pytest tests/api/test_router_mounting.py tests/api/projects/test_create_project.py tests/api/test_documents_patch.py tests/api/test_approvals_usage_event.py


------
https://chatgpt.com/codex/tasks/task_e_68d0eb24e1548329817123f8f8e5bbc1