### PR TITLE
Implement secure FastAPI auth integration

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getApiBaseUrl } from "@/lib/server/api-config";
+
+interface LoginRequestBody {
+  email?: string;
+  password?: string;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type?: string;
+  expires_in?: number;
+  user?: unknown;
+}
+
+const ACCESS_COOKIE = "originfd_access_token";
+const REFRESH_COOKIE = "originfd_refresh_token";
+
+const isProduction = process.env.NODE_ENV === "production";
+
+const secureCookieOptions = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: "lax" as const,
+  path: "/",
+};
+
+async function fetchCurrentUser(accessToken: string) {
+  const baseUrl = getApiBaseUrl();
+  const response = await fetch(`${baseUrl}/auth/me`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Response(errorBody || "Failed to fetch user", {
+      status: response.status,
+    });
+  }
+
+  return response.json();
+}
+
+export async function POST(request: NextRequest) {
+  const baseUrl = getApiBaseUrl();
+  let body: LoginRequestBody;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { detail: "Invalid login payload" },
+      { status: 400 },
+    );
+  }
+
+  if (!body.email || !body.password) {
+    return NextResponse.json(
+      { detail: "Email and password are required" },
+      { status: 400 },
+    );
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(`${baseUrl}/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: body.email, password: body.password }),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { detail: "Unable to reach authentication service" },
+      { status: 502 },
+    );
+  }
+
+  const responseData = (await backendResponse
+    .json()
+    .catch(() => null)) as TokenResponse | null;
+
+  if (!backendResponse.ok || !responseData) {
+    const errorDetail =
+      (responseData as any)?.detail || "Authentication failed";
+    return NextResponse.json(
+      { detail: errorDetail },
+      { status: backendResponse.status || 500 },
+    );
+  }
+
+  const { access_token: accessToken, refresh_token: refreshToken } =
+    responseData;
+
+  if (!accessToken || !refreshToken) {
+    return NextResponse.json(
+      { detail: "Authentication tokens missing from response" },
+      { status: 500 },
+    );
+  }
+
+  let userPayload = responseData.user ?? null;
+
+  if (!userPayload) {
+    try {
+      userPayload = await fetchCurrentUser(accessToken);
+    } catch (error: unknown) {
+      if (error instanceof Response) {
+        return NextResponse.json(
+          { detail: "Authenticated but failed to load user" },
+          { status: error.status },
+        );
+      }
+
+      return NextResponse.json(
+        { detail: "Authenticated but failed to load user" },
+        { status: 502 },
+      );
+    }
+  }
+
+  const response = NextResponse.json({ user: userPayload });
+
+  const accessTokenMaxAge = responseData.expires_in
+    ? Math.max(responseData.expires_in, 60)
+    : 60 * 30;
+
+  response.cookies.set(ACCESS_COOKIE, accessToken, {
+    ...secureCookieOptions,
+    maxAge: accessTokenMaxAge,
+  });
+
+  response.cookies.set(REFRESH_COOKIE, refreshToken, {
+    ...secureCookieOptions,
+    maxAge: 60 * 60 * 24 * 30,
+  });
+
+  return response;
+}

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+const ACCESS_COOKIE = "originfd_access_token";
+const REFRESH_COOKIE = "originfd_refresh_token";
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+  const cookieStore = cookies();
+
+  if (cookieStore.get(ACCESS_COOKIE)) {
+    response.cookies.delete(ACCESS_COOKIE);
+  }
+
+  if (cookieStore.get(REFRESH_COOKIE)) {
+    response.cookies.delete(REFRESH_COOKIE);
+  }
+
+  return response;
+}

--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -1,0 +1,42 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { getApiBaseUrl } from "@/lib/server/api-config";
+
+const ACCESS_COOKIE = "originfd_access_token";
+
+export async function GET() {
+  const cookieStore = cookies();
+  const token = cookieStore.get(ACCESS_COOKIE)?.value;
+
+  if (!token) {
+    return NextResponse.json({ detail: "Not authenticated" }, { status: 401 });
+  }
+
+  const baseUrl = getApiBaseUrl();
+  let response: Response;
+
+  try {
+    response = await fetch(`${baseUrl}/auth/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { detail: "Unable to reach authentication service" },
+      { status: 502 },
+    );
+  }
+
+  const body = await response.text();
+  const contentType = response.headers.get("content-type") || "application/json";
+
+  return new NextResponse(body || "{}", {
+    status: response.status,
+    headers: {
+      "content-type": contentType,
+    },
+  });
+}

--- a/apps/web/src/app/api/proxy/[...path]/route.ts
+++ b/apps/web/src/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,126 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import { getApiBaseUrl } from "@/lib/server/api-config";
+
+const ACCESS_COOKIE = "originfd_access_token";
+
+function buildTargetUrl(request: NextRequest, pathSegments: string[]): string {
+  const baseUrl = getApiBaseUrl();
+  const path = pathSegments.join("/");
+  const url = new URL(request.url);
+  const search = url.search ? url.search : "";
+  const normalizedPath = path ? `/${path}` : "";
+  return `${baseUrl}${normalizedPath}${search}`;
+}
+
+function filterHeaders(headers: Headers, token?: string): Headers {
+  const result = new Headers();
+
+  headers.forEach((value, key) => {
+    const lowerKey = key.toLowerCase();
+    if (["host", "connection", "accept-encoding"].includes(lowerKey)) {
+      return;
+    }
+
+    if (lowerKey === "cookie") {
+      return;
+    }
+
+    result.set(key, value);
+  });
+
+  if (token) {
+    result.set("Authorization", `Bearer ${token}`);
+  }
+
+  return result;
+}
+
+async function proxyRequest(request: NextRequest, path: string[]) {
+  const token = cookies().get(ACCESS_COOKIE)?.value;
+  const targetUrl = buildTargetUrl(request, path);
+  const headers = filterHeaders(new Headers(request.headers), token);
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "manual",
+    cache: "no-store",
+  };
+
+  if (![
+    "GET",
+    "HEAD",
+  ].includes(request.method.toUpperCase())) {
+    if (request.body) {
+      init.body = request.body;
+      (init as any).duplex = "half";
+    }
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(targetUrl, init);
+  } catch (error) {
+    return NextResponse.json(
+      { detail: "Upstream request failed" },
+      { status: 502 },
+    );
+  }
+  const responseHeaders = new Headers();
+  backendResponse.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "transfer-encoding") {
+      return;
+    }
+    responseHeaders.set(key, value);
+  });
+
+  return new NextResponse(backendResponse.body, {
+    status: backendResponse.status,
+    headers: responseHeaders,
+  });
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: { path: string[] } },
+) {
+  return proxyRequest(request, context.params.path);
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: { path: string[] } },
+) {
+  return proxyRequest(request, context.params.path);
+}
+
+export async function PUT(
+  request: NextRequest,
+  context: { params: { path: string[] } },
+) {
+  return proxyRequest(request, context.params.path);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: { path: string[] } },
+) {
+  return proxyRequest(request, context.params.path);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: { path: string[] } },
+) {
+  return proxyRequest(request, context.params.path);
+}
+
+export async function OPTIONS(
+  request: NextRequest,
+  context: { params: { path: string[] } },
+) {
+  return proxyRequest(request, context.params.path);
+}

--- a/apps/web/src/components/lifecycle/lifecycle-dashboard.tsx
+++ b/apps/web/src/components/lifecycle/lifecycle-dashboard.tsx
@@ -75,7 +75,7 @@ export default function LifecycleDashboard({
   const { data: lifecycleData, isLoading } = useQuery({
     queryKey: ["components-lifecycle", stageFilter, searchQuery],
     queryFn: async () => {
-      const response = await fetch("/api/bridge/components");
+      const response = await fetch("/api/proxy/components");
       if (!response.ok) throw new Error("Failed to fetch components");
       return response.json();
     },
@@ -85,7 +85,7 @@ export default function LifecycleDashboard({
   const { data: stats } = useQuery({
     queryKey: ["component-stats"],
     queryFn: async () => {
-      const response = await fetch("/api/bridge/components/stats");
+      const response = await fetch("/api/proxy/components/stats");
       if (!response.ok) throw new Error("Failed to fetch stats");
       return response.json();
     },
@@ -99,7 +99,7 @@ export default function LifecycleDashboard({
       reason: string;
     }) => {
       const response = await fetch(
-        `/api/bridge/components/${data.componentId}/lifecycle`,
+        `/api/proxy/components/${data.componentId}/lifecycle`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/apps/web/src/components/media/media-asset-manager.tsx
+++ b/apps/web/src/components/media/media-asset-manager.tsx
@@ -152,7 +152,7 @@ export default function MediaAssetManager({
   } = useQuery({
     queryKey: ["media-assets", componentId, typeFilter],
     queryFn: async () => {
-      let url = "/api/bridge/media";
+      let url = "/api/proxy/media";
       const params = new URLSearchParams();
 
       if (componentId) params.append("component_id", componentId);
@@ -170,7 +170,7 @@ export default function MediaAssetManager({
   // Upload mutation
   const uploadMutation = useMutation({
     mutationFn: async (assetData: any) => {
-      const response = await fetch("/api/bridge/media", {
+      const response = await fetch("/api/proxy/media", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(assetData),

--- a/apps/web/src/components/operations/alarm-panel.tsx
+++ b/apps/web/src/components/operations/alarm-panel.tsx
@@ -47,7 +47,7 @@ export default function AlarmPanel() {
 
   const createWorkOrder = async (alarmId: string) => {
     try {
-      await fetch("/api/bridge/work-orders", {
+      await fetch("/api/proxy/work-orders", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ alarm_id: alarmId }),

--- a/apps/web/src/components/purchase-orders/po-dashboard.tsx
+++ b/apps/web/src/components/purchase-orders/po-dashboard.tsx
@@ -123,7 +123,7 @@ export default function PODashboard({
   } = useQuery({
     queryKey: ["purchase-orders", statusFilter, searchTerm],
     queryFn: async () => {
-      let url = "/api/bridge/purchase-orders";
+      let url = "/api/proxy/purchase-orders";
       const params = new URLSearchParams();
 
       if (statusFilter !== "all") params.append("status", statusFilter);
@@ -145,7 +145,7 @@ export default function PODashboard({
       notes: string;
     }) => {
       const response = await fetch(
-        `/api/bridge/purchase-orders/${data.poId}/approve`,
+        `/api/proxy/purchase-orders/${data.poId}/approve`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -176,7 +176,7 @@ export default function PODashboard({
       notes: string;
     }) => {
       const response = await fetch(
-        `/api/bridge/purchase-orders/${data.poId}/status`,
+        `/api/proxy/purchase-orders/${data.poId}/status`,
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },

--- a/apps/web/src/components/rfq/rfq-creation-wizard.tsx
+++ b/apps/web/src/components/rfq/rfq-creation-wizard.tsx
@@ -109,7 +109,7 @@ export default function RFQCreationWizard({
   const { data: components } = useQuery({
     queryKey: ["components-available"],
     queryFn: async () => {
-      const response = await fetch("/api/bridge/components?status=available");
+      const response = await fetch("/api/proxy/components?status=available");
       if (!response.ok) throw new Error("Failed to fetch components");
       return response.json();
     },
@@ -119,7 +119,7 @@ export default function RFQCreationWizard({
   // Create RFQ mutation
   const createRFQMutation = useMutation({
     mutationFn: async (data: RFQFormData) => {
-      const response = await fetch("/api/bridge/rfq", {
+      const response = await fetch("/api/proxy/rfq", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/apps/web/src/components/rfq/rfq-dashboard.tsx
+++ b/apps/web/src/components/rfq/rfq-dashboard.tsx
@@ -92,7 +92,7 @@ export default function RFQDashboard({
   } = useQuery({
     queryKey: ["rfqs", statusFilter],
     queryFn: async () => {
-      const response = await fetch("/api/bridge/rfq");
+      const response = await fetch("/api/proxy/rfq");
       if (!response.ok) throw new Error("Failed to fetch RFQs");
       return response.json();
     },

--- a/apps/web/src/components/suppliers/supplier-portal.tsx
+++ b/apps/web/src/components/suppliers/supplier-portal.tsx
@@ -126,7 +126,7 @@ export default function SupplierPortal({
   const { data: availableRFQs = [], isLoading: rfqsLoading } = useQuery({
     queryKey: ["supplier-rfqs", "receiving_bids"],
     queryFn: async () => {
-      const response = await fetch("/api/bridge/rfq?status=receiving_bids");
+      const response = await fetch("/api/proxy/rfq?status=receiving_bids");
       if (!response.ok) throw new Error("Failed to fetch RFQs");
       return response.json();
     },
@@ -138,7 +138,7 @@ export default function SupplierPortal({
     queryFn: async () => {
       // In real implementation, this would fetch bids by supplier_id
       // For now, we'll filter from available RFQs
-      const allRFQs = await fetch("/api/bridge/rfq").then((r) => r.json());
+      const allRFQs = await fetch("/api/proxy/rfq").then((r) => r.json());
       const bids: RFQBid[] = [];
 
       allRFQs.forEach((rfq: RFQRequest) => {
@@ -160,7 +160,7 @@ export default function SupplierPortal({
   // Submit bid mutation
   const submitBidMutation = useMutation({
     mutationFn: async (data: { rfqId: string; bidData: any }) => {
-      const response = await fetch(`/api/bridge/rfq/${data.rfqId}/bids`, {
+      const response = await fetch(`/api/proxy/rfq/${data.rfqId}/bids`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/apps/web/src/lib/server/api-config.ts
+++ b/apps/web/src/lib/server/api-config.ts
@@ -1,0 +1,16 @@
+const API_ENV_KEYS = [
+  "ORIGINFD_API_URL",
+  "NEXT_PUBLIC_API_URL",
+  "API_URL",
+];
+
+export function getApiBaseUrl(): string {
+  for (const key of API_ENV_KEYS) {
+    const value = process.env[key];
+    if (value && value.trim().length > 0) {
+      return value.replace(/\/+$/, "");
+    }
+  }
+
+  return "http://localhost:8000";
+}


### PR DESCRIPTION
## Summary
- add Next.js API routes to broker FastAPI auth endpoints and persist issued JWTs in http-only cookies
- refactor the shared API client and auth provider to use the proxy-backed authentication flow
- update UI fetchers and Playwright fixtures to target the new `/api/proxy` surface instead of bridge mocks

## Testing
- pnpm test *(fails: Next.js dev server cannot resolve the `@originfd/ui` workspace package during Playwright startup)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f1902be883298dcef379afe4fda9