### PR TITLE
fix: harden auth tokens and clean API models

### DIFF
--- a/services/api/models/document.py
+++ b/services/api/models/document.py
@@ -2,8 +2,6 @@
 Database models for ODL-SD documents.
 """
 
-from datetime import datetime
-
 from sqlalchemy import (
     Boolean,
     Column,
@@ -16,7 +14,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import text
 
 from .base import Base, TenantMixin, TimestampMixin, UUIDMixin
 
@@ -56,7 +53,13 @@ class Document(Base, UUIDMixin, TimestampMixin, TenantMixin):
     access_controls = relationship("DocumentAccess", back_populates="document")
 
     def __repr__(self):
-        return f"<Document(id={self.id}, project={self.project_name}, version={self.current_version})>"
+        return (
+            "<Document(id={id}, project={project}, version={version})>".format(
+                id=self.id,
+                project=self.project_name,
+                version=self.current_version,
+            )
+        )
 
 
 class DocumentVersion(Base, UUIDMixin, TimestampMixin, TenantMixin):
@@ -93,7 +96,12 @@ class DocumentVersion(Base, UUIDMixin, TimestampMixin, TenantMixin):
     document = relationship("Document", back_populates="versions")
 
     def __repr__(self):
-        return f"<DocumentVersion(document_id={self.document_id}, version={self.version_number})>"
+        return (
+            "<DocumentVersion(document_id={doc}, version={version})>".format(
+                doc=self.document_id,
+                version=self.version_number,
+            )
+        )
 
 
 class DocumentAccess(Base, UUIDMixin, TimestampMixin, TenantMixin):
@@ -114,7 +122,8 @@ class DocumentAccess(Base, UUIDMixin, TimestampMixin, TenantMixin):
 
     # Permission flags
     permissions = Column(
-        JSONB, nullable=False
+        JSONB,
+        nullable=False,
     )  # {"read": true, "write": false, "approve": false}
 
     # Access constraints
@@ -129,7 +138,13 @@ class DocumentAccess(Base, UUIDMixin, TimestampMixin, TenantMixin):
     document = relationship("Document", back_populates="access_controls")
 
     def __repr__(self):
-        return f"<DocumentAccess(document_id={self.document_id}, user_id={self.user_id}, role={self.role})>"
+        return (
+            "<DocumentAccess(document_id={doc}, user_id={user}, role={role})>".format(
+                doc=self.document_id,
+                user=self.user_id,
+                role=self.role,
+            )
+        )
 
 
 # Row Level Security (RLS) policies - applied at database level

--- a/services/api/models/project.py
+++ b/services/api/models/project.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import BaseModel
 from sqlalchemy import Boolean, Column
@@ -21,6 +21,10 @@ from .base import Base, TimestampMixin, UUIDMixin
 def _document_id_column():
     from services.api.models.document import Document
     return Document.__table__.c.id
+
+
+if TYPE_CHECKING:
+    from .document import Document
 
 
 class ProjectDomain(str, Enum):
@@ -81,13 +85,11 @@ class Project(Base, UUIDMixin, TimestampMixin):
     primary_document: Optional["Document"] = relationship(
         "Document",
         foreign_keys=[primary_document_id],
-        primaryjoin=lambda: Project.primary_document_id == foreign(_document_id_column()),
+        primaryjoin=lambda: Project.primary_document_id
+        == foreign(_document_id_column()),
     )
     is_archived = Column(Boolean, default=False)
     initialization_task_id = Column(String, nullable=True)
-    primary_document_id = Column(
-        UUID(as_uuid=True), ForeignKey("documents.id"), nullable=True
-    )
 
     lifecycle_phases = relationship(
         "LifecyclePhase",

--- a/services/api/models/tenant.py
+++ b/services/api/models/tenant.py
@@ -2,9 +2,7 @@
 Tenant model for multi-tenant architecture.
 """
 
-from datetime import datetime
-
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy import Boolean, Column, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 


### PR DESCRIPTION
## Summary
- stop using hardcoded JWT secrets in the auth router, tighten mock logic, and document backend guardrails
- clean FastAPI main module imports/registrations and reformat performance metrics for lint compliance
- resolve SQLAlchemy forward references and line-length issues in document, project, and tenant models

## Testing
- pytest tests -q *(fails: existing orchestrator tool merge conflict markers and missing jsonpatch dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b05434fc8329851936432b348f74